### PR TITLE
Make CLI better match Vault

### DIFF
--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -134,7 +134,18 @@ func (b *backend) configReadOperation(ctx context.Context, req *logical.Request,
 	// NOTE:
 	// "password" is intentionally not returned by this endpoint,
 	// as we lean away from returning sensitive information unless it's absolutely necessary.
-	configMap := config.ADConf.PasswordlessMap()
+	// Also, we don't return the full ADConf here because not all parameters are used by this engine.
+	configMap := map[string]interface{}{
+		"url":             config.ADConf.Url,
+		"starttls":        config.ADConf.StartTLS,
+		"insecure_tls":    config.ADConf.InsecureTLS,
+		"certificate":     config.ADConf.Certificate,
+		"binddn":          config.ADConf.BindDN,
+		"userdn":          config.ADConf.UserDN,
+		"upndomain":       config.ADConf.UPNDomain,
+		"tls_min_version": config.ADConf.TLSMinVersion,
+		"tls_max_version": config.ADConf.TLSMaxVersion,
+	}
 	for k, v := range config.PasswordConf.Map() {
 		configMap[k] = v
 	}

--- a/plugin/path_creds.go
+++ b/plugin/path_creds.go
@@ -87,7 +87,7 @@ func (b *backend) credReadOperation(ctx context.Context, req *logical.Request, f
 		return nil, err
 	}
 	if role == nil {
-		return nil, fmt.Errorf("%s not found", roleName)
+		return nil, nil
 	}
 
 	var resp *logical.Response

--- a/plugin/path_roles.go
+++ b/plugin/path_roles.go
@@ -180,7 +180,7 @@ func (b *backend) roleReadOperation(ctx context.Context, req *logical.Request, f
 		return nil, err
 	}
 	if role == nil {
-		return nil, fmt.Errorf("%s not found", roleName)
+		return nil, nil
 	}
 
 	return &logical.Response{


### PR DESCRIPTION
I did some final integration testing today to make sure everything worked. In doing so I noticed a couple of issues:
- When you added a config, and then read it, it gave back all ldap config parameters possible, even ones not used by this engine, which could easily confuse the user.
- When you tried to read a non-existent thing, you got a 500 instead of a 404.

This fixes those.