### PR TITLE
Rename github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you wish to work on this plugin, you'll first need
 For local dev first make sure Go is properly installed, including
 setting up a [GOPATH](https://golang.org/doc/code.html#GOPATH).
 Next, clone this repository into
-`$GOPATH/src/github.com/hashicorp/vault-plugin-secrets-active-directory`.
+`$GOPATH/src/github.com/hashicorp/vault-plugin-secrets-ad`.
 You can then download any required build tools by bootstrapping your
 environment:
 
@@ -83,7 +83,7 @@ Once the server is started, register the plugin in the Vault server's [plugin ca
 ```sh
 $ vault write sys/plugins/catalog/ad \
         sha_256=<expected SHA256 Hex value of the plugin binary> \
-        command="vault-plugin-secrets-active-directory"
+        command="vault-plugin-secrets-ad"
 ...
 Success! Data written to: sys/plugins/catalog/ad
 ```
@@ -92,9 +92,9 @@ Note you should generate a new sha256 checksum if you have made changes
 to the plugin. Example using openssl:
 
 ```sh
-openssl dgst -sha256 $GOPATH/vault-plugin-secrets-active-directory
+openssl dgst -sha256 $GOPATH/vault-plugin-secrets-ad
 ...
-SHA256(.../go/bin/vault-plugin-secrets-active-directory)= 896c13c0f5305daed381952a128322e02bc28a57d0c862a78cbc2ea66e8c6fa1
+SHA256(.../go/bin/vault-plugin-secrets-ad)= 896c13c0f5305daed381952a128322e02bc28a57d0c862a78cbc2ea66e8c6fa1
 ```
 
 Enable the auth plugin backend using the secrets enable plugin command:

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	hclog "github.com/hashicorp/go-hclog"
-	ad "github.com/hashicorp/vault-plugin-secrets-active-directory/plugin"
+	ad "github.com/hashicorp/vault-plugin-secrets-ad/plugin"
 	"github.com/hashicorp/vault/helper/pluginutil"
 	"github.com/hashicorp/vault/logical/plugin"
 )

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/vault-plugin-secrets-active-directory/plugin/client"
-	"github.com/hashicorp/vault-plugin-secrets-active-directory/plugin/util"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
 	"github.com/hashicorp/vault/helper/ldaputil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/go-ldap/ldap"
-	"github.com/hashicorp/vault-plugin-secrets-active-directory/plugin/client"
-	"github.com/hashicorp/vault-plugin-secrets-active-directory/plugin/util"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
 	"github.com/hashicorp/vault/helper/ldaputil"
 	"github.com/hashicorp/vault/logical"
 )

--- a/plugin/client/client_test.go
+++ b/plugin/client/client_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-ldap/ldap"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault-plugin-secrets-active-directory/plugin/ldapifc"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/ldapifc"
 	"github.com/hashicorp/vault/helper/ldaputil"
 )
 

--- a/plugin/client/tools/simplecall.go
+++ b/plugin/client/tools/simplecall.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault-plugin-secrets-active-directory/plugin/client"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
 	"github.com/hashicorp/vault/helper/ldaputil"
 )
 

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/vault-plugin-secrets-active-directory/plugin/util"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
 	"github.com/hashicorp/vault/helper/ldaputil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"

--- a/plugin/path_creds.go
+++ b/plugin/path_creds.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/go-errors/errors"
-	"github.com/hashicorp/vault-plugin-secrets-active-directory/plugin/util"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )

--- a/plugin/util/secrets_client.go
+++ b/plugin/util/secrets_client.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault-plugin-secrets-active-directory/plugin/client"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
 	"github.com/hashicorp/vault/helper/ldaputil"
 )
 


### PR DESCRIPTION
I found that for my plugin to build in Vault, I needed to rename the repo from `vault-plugin-secrets-active-directory` to `vault-plugin-secrets-ad` because Vault parses the backend's name from the repo's name.