### PR TITLE
Add ability to provide custom password format

### DIFF
--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -275,9 +275,6 @@ func ReadCred(t *testing.T) {
 	if !strings.HasPrefix(password, util.PasswordComplexityPrefix) {
 		t.Fatalf("%s doesn't have the expected complexity prefix of %s", password, util.PasswordComplexityPrefix)
 	}
-	if len(password) < util.MinimumPasswordLength {
-		t.Fatalf("%s is too short", password)
-	}
 }
 
 const validCertificate = `

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -63,6 +63,7 @@ func WriteConfig(t *testing.T) {
 			"url":         "ldap://138.91.247.105",
 			"certificate": validCertificate,
 			"userdn":      "dc=example,dc=com",
+			"formatter":   "mycustom{{PASSWORD}}",
 		},
 	}
 	resp, err := testBackend.HandleRequest(testCtx, req)
@@ -124,6 +125,10 @@ func ReadConfig(t *testing.T) {
 
 	if resp.Data["length"] != defaultPasswordLength {
 		t.Fatalf("received unexpected length of \"%d\"", resp.Data["length"])
+	}
+
+	if resp.Data["formatter"] != "mycustom{{PASSWORD}}" {
+		t.Fatalf("received unexpected formatter of \"%d\"", resp.Data["formatter"])
 	}
 }
 

--- a/plugin/passwordconf.go
+++ b/plugin/passwordconf.go
@@ -1,15 +1,17 @@
 package plugin
 
 type passwordConf struct {
-	TTL    int `json:"ttl"`
-	MaxTTL int `json:"max_ttl"`
-	Length int `json:"length"`
+	TTL       int    `json:"ttl"`
+	MaxTTL    int    `json:"max_ttl"`
+	Length    int    `json:"length"`
+	Formatter string `json:"formatter"`
 }
 
 func (c *passwordConf) Map() map[string]interface{} {
 	return map[string]interface{}{
-		"ttl":     c.TTL,
-		"max_ttl": c.MaxTTL,
-		"length":  c.Length,
+		"ttl":       c.TTL,
+		"max_ttl":   c.MaxTTL,
+		"length":    c.Length,
+		"formatter": c.Formatter,
 	}
 }

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
 	"github.com/hashicorp/vault/helper/ldaputil"
@@ -105,9 +104,10 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 	if maxTTL < 1 {
 		return nil, errors.New("max_ttl must be positive")
 	}
-	if length < util.MinimumPasswordLength {
-		return nil, fmt.Errorf("minimum password length is %d for sufficient complexity to be secure, though Vault recommends a higher length", util.MinimumPasswordLength)
+	if err := util.ValidatePwdSettings(formatter, length); err != nil {
+		return nil, err
 	}
+
 	passwordConf := &passwordConf{
 		TTL:       ttl,
 		MaxTTL:    maxTTL,

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -68,7 +68,7 @@ func (b *backend) configFields() map[string]*framework.FieldSchema {
 	}
 	fields["formatter"] = &framework.FieldSchema{
 		Type:        framework.TypeString,
-		Description: "Text to insert the password into, ex. \"customPrefix{{PASSWORD}}customSuffix\".",
+		Description: `Text to insert the password into, ex. "customPrefix{{PASSWORD}}customSuffix".`,
 	}
 	return fields
 }

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -67,6 +67,10 @@ func (b *backend) configFields() map[string]*framework.FieldSchema {
 		Default:     defaultPasswordLength,
 		Description: "The desired length of passwords that Vault generates.",
 	}
+	fields["formatter"] = &framework.FieldSchema{
+		Type:        framework.TypeString,
+		Description: "Text to insert the password into, ex. \"customPrefix{{PASSWORD}}customSuffix\".",
+	}
 	return fields
 }
 
@@ -84,6 +88,7 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 	ttl := fieldData.Get("ttl").(int)
 	maxTTL := fieldData.Get("max_ttl").(int)
 	length := fieldData.Get("length").(int)
+	formatter := fieldData.Get("formatter").(string)
 
 	if ttl == 0 {
 		ttl = int(b.System().DefaultLeaseTTL().Seconds())
@@ -104,9 +109,10 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 		return nil, fmt.Errorf("minimum password length is %d for sufficient complexity to be secure, though Vault recommends a higher length", util.MinimumPasswordLength)
 	}
 	passwordConf := &passwordConf{
-		TTL:    ttl,
-		MaxTTL: maxTTL,
-		Length: length,
+		TTL:       ttl,
+		MaxTTL:    maxTTL,
+		Length:    length,
+		Formatter: formatter,
 	}
 
 	config := &configuration{passwordConf, activeDirectoryConf}

--- a/plugin/path_creds.go
+++ b/plugin/path_creds.go
@@ -158,7 +158,7 @@ func (b *backend) generateAndReturnCreds(ctx context.Context, storage logical.St
 		return nil, errors.New("the config is currently unset")
 	}
 
-	newPassword, err := util.GeneratePassword(engineConf.PasswordConf.Length)
+	newPassword, err := util.GeneratePassword(engineConf.PasswordConf.Formatter, engineConf.PasswordConf.Length)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/util/passwords.go
+++ b/plugin/util/passwords.go
@@ -3,11 +3,14 @@ package util
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-uuid"
 )
 
 var (
+	pwdFieldTmpl = "{{PASSWORD}}"
+
 	// Per https://en.wikipedia.org/wiki/Password_strength#Guidelines_for_strong_passwords
 	minimumLengthOfComplexString = 8
 
@@ -15,16 +18,41 @@ var (
 	MinimumPasswordLength    = len(PasswordComplexityPrefix) + minimumLengthOfComplexString
 )
 
-func GeneratePassword(desiredLength int) (string, error) {
+func GeneratePassword(formatter string, desiredLength int) (string, error) {
 	if desiredLength < MinimumPasswordLength {
 		return "", fmt.Errorf("it's not possible to generate a _secure_ password of length %d, please boost length to %d, though Vault recommends higher", desiredLength, MinimumPasswordLength)
 	}
+	result, err := generatePassword(desiredLength)
+	if err != nil {
+		return "", err
+	}
+	if formatter == "" {
+		result = PasswordComplexityPrefix + result
+		return result[:desiredLength], nil
+	}
+	numPasswordFields := strings.Count(formatter, pwdFieldTmpl)
+	if numPasswordFields == 0 {
+		return "", fmt.Errorf("%s must contain password replacement field of %s", formatter, pwdFieldTmpl)
+	}
 
+	// Use the password generated earlier before generating more.
+	formatter = strings.Replace(formatter, pwdFieldTmpl, result[:desiredLength], 1)
+
+	for i := 1; i < numPasswordFields; i++ {
+		result, err = generatePassword(desiredLength)
+		if err != nil {
+			return "", err
+		}
+		formatter = strings.Replace(formatter, pwdFieldTmpl, result[:desiredLength], 1)
+	}
+	return formatter, nil
+}
+
+func generatePassword(desiredLength int) (string, error) {
 	b, err := uuid.GenerateRandomBytes(desiredLength)
 	if err != nil {
 		return "", err
 	}
-
 	result := ""
 	// Though the result should immediately be longer than the desiredLength,
 	// do this in a loop to ensure there's absolutely no risk of a panic when slicing it down later.
@@ -32,7 +60,5 @@ func GeneratePassword(desiredLength int) (string, error) {
 		// Encode to base64 because it's more complex.
 		result += base64.StdEncoding.EncodeToString(b)
 	}
-
-	result = PasswordComplexityPrefix + result
-	return result[:desiredLength], nil
+	return result, nil
 }

--- a/plugin/util/passwords.go
+++ b/plugin/util/passwords.go
@@ -49,7 +49,7 @@ func ValidatePwdSettings(formatter string, totalLength int) error {
 		return fmt.Errorf("%s must contain password replacement field of %s", formatter, PwdFieldTmpl)
 	}
 	if numPwdFields > 1 {
-		fmt.Errorf("%s must contain ONE password replacement field of %s", formatter, PwdFieldTmpl)
+		return fmt.Errorf("%s must contain ONE password replacement field of %s", formatter, PwdFieldTmpl)
 	}
 	return nil
 }

--- a/plugin/util/passwords.go
+++ b/plugin/util/passwords.go
@@ -9,45 +9,58 @@ import (
 )
 
 var (
-	pwdFieldTmpl = "{{PASSWORD}}"
-
 	// Per https://en.wikipedia.org/wiki/Password_strength#Guidelines_for_strong_passwords
 	minimumLengthOfComplexString = 8
 
 	PasswordComplexityPrefix = "?@09AZ"
-	MinimumPasswordLength    = len(PasswordComplexityPrefix) + minimumLengthOfComplexString
+	PwdFieldTmpl             = "{{PASSWORD}}"
 )
 
-func GeneratePassword(formatter string, desiredLength int) (string, error) {
-	if desiredLength < MinimumPasswordLength {
-		return "", fmt.Errorf("it's not possible to generate a _secure_ password of length %d, please boost length to %d, though Vault recommends higher", desiredLength, MinimumPasswordLength)
+func GeneratePassword(formatter string, totalLength int) (string, error) {
+	if err := ValidatePwdSettings(formatter, totalLength); err != nil {
+		return "", err
 	}
-	result, err := generatePassword(desiredLength)
+	pwd, err := generatePassword(totalLength)
 	if err != nil {
 		return "", err
 	}
 	if formatter == "" {
-		result = PasswordComplexityPrefix + result
-		return result[:desiredLength], nil
+		pwd = PasswordComplexityPrefix + pwd
+		return pwd[:totalLength], nil
 	}
-	numPasswordFields := strings.Count(formatter, pwdFieldTmpl)
-	if numPasswordFields == 0 {
-		return "", fmt.Errorf("%s must contain password replacement field of %s", formatter, pwdFieldTmpl)
-	}
-
-	// Use the password generated earlier before generating more.
-	formatter = strings.Replace(formatter, pwdFieldTmpl, result[:desiredLength], 1)
-
-	for i := 1; i < numPasswordFields; i++ {
-		result, err = generatePassword(desiredLength)
-		if err != nil {
-			return "", err
-		}
-		formatter = strings.Replace(formatter, pwdFieldTmpl, result[:desiredLength], 1)
-	}
-	return formatter, nil
+	return strings.Replace(formatter, PwdFieldTmpl, pwd[:lengthOfPassword(formatter, totalLength)], 1), nil
 }
 
+func ValidatePwdSettings(formatter string, totalLength int) error {
+	// Check for if there's no formatter.
+	if formatter == "" {
+		if totalLength < len(PasswordComplexityPrefix)+minimumLengthOfComplexString {
+			return fmt.Errorf("it's not possible to generate a _secure_ password of length %d, please boost length to %d, though Vault recommends higher", totalLength, minimumLengthOfComplexString)
+		}
+		return nil
+	}
+
+	// Check for if there is a formatter.
+	if lengthOfPassword(formatter, totalLength) < minimumLengthOfComplexString {
+		return fmt.Errorf("since the desired length is %d, it isn't possible to generate a sufficiently complex password - please increase desired length or remove characters from the formatter", totalLength)
+	}
+	numPwdFields := strings.Count(formatter, PwdFieldTmpl)
+	if numPwdFields == 0 {
+		return fmt.Errorf("%s must contain password replacement field of %s", formatter, PwdFieldTmpl)
+	}
+	if numPwdFields > 1 {
+		fmt.Errorf("%s must contain ONE password replacement field of %s", formatter, PwdFieldTmpl)
+	}
+	return nil
+}
+
+func lengthOfPassword(formatter string, totalLength int) int {
+	lengthOfText := len(formatter) - len(PwdFieldTmpl)
+	return totalLength - lengthOfText
+}
+
+// generatePassword returns a password of a length AT LEAST as long as the desired length,
+// it may be longer.
 func generatePassword(desiredLength int) (string, error) {
 	b, err := uuid.GenerateRandomBytes(desiredLength)
 	if err != nil {

--- a/plugin/util/passwords_test.go
+++ b/plugin/util/passwords_test.go
@@ -10,7 +10,7 @@ func TestGeneratePassword(t *testing.T) {
 
 		password1, err := GeneratePassword("", desiredLength)
 
-		if desiredLength < MinimumPasswordLength {
+		if desiredLength < len(PasswordComplexityPrefix)+minimumLengthOfComplexString {
 			if err == nil {
 				t.Fatalf("desiredLength of %d should yield an error", desiredLength)
 			} else {
@@ -41,65 +41,57 @@ func TestGeneratePassword(t *testing.T) {
 
 func TestFormatPassword(t *testing.T) {
 
-	testStrLen := len("helloworld")
+	desiredLength := len("helloworld") + minimumLengthOfComplexString
 
 	// Test with {{PASSWORD}} in the middle of the formatter.
-	password, err := GeneratePassword("hello{{PASSWORD}}world", MinimumPasswordLength)
+	password, err := GeneratePassword("hello{{PASSWORD}}world", desiredLength)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	if len(password) != (MinimumPasswordLength + testStrLen) {
+	if len(password) != desiredLength {
 		t.Fatalf("unexpected password length of %d in %s", len(password), password)
 	}
 
 	// Test with {{PASSWORD}} at the start of the formatter.
-	password, err = GeneratePassword("{{PASSWORD}}helloworld", MinimumPasswordLength)
+	password, err = GeneratePassword("{{PASSWORD}}helloworld", desiredLength)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	if len(password) != (MinimumPasswordLength + testStrLen) {
+	if len(password) != desiredLength {
 		t.Fatalf("unexpected password length of %d in %s", len(password), password)
 	}
 
 	// Test with {{PASSWORD}} at the end of the formatter.
-	password, err = GeneratePassword("helloworld{{PASSWORD}}", MinimumPasswordLength)
+	password, err = GeneratePassword("helloworld{{PASSWORD}}", desiredLength)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	if len(password) != (MinimumPasswordLength + testStrLen) {
+	if len(password) != desiredLength {
 		t.Fatalf("unexpected password length of %d in %s", len(password), password)
 	}
 
 	// Test with {{PASSWORD}} not provided so essentially they're trying to provide an unchanging password,
 	// defeating the purpose of Vault.
-	password, err = GeneratePassword("helloworld", MinimumPasswordLength)
+	password, err = GeneratePassword("helloworld", desiredLength)
 	if err == nil {
 		t.Fatal("should have received an error because a static password was provided as the formatter")
 	}
 
 	// Test normal, non-custom formatting path.
-	password, err = GeneratePassword("", MinimumPasswordLength)
+	password, err = GeneratePassword("", desiredLength)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	if len(password) != MinimumPasswordLength {
-		t.Fatalf("unexpected password length of %d in %s", MinimumPasswordLength, password)
+	if len(password) != desiredLength {
+		t.Fatalf("unexpected password length of %d in %s", minimumLengthOfComplexString, password)
 	}
 	if !strings.HasPrefix(password, PasswordComplexityPrefix) {
 		t.Fatalf("%s should have complexity prefix of %s", password, PasswordComplexityPrefix)
 	}
 
 	// Test password being provided twice. Should be two different passwords.
-	password, err = GeneratePassword("hello{{PASSWORD}}worldhello{{PASSWORD}}world", MinimumPasswordLength)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	if len(password) != (MinimumPasswordLength+testStrLen)*2 {
-		t.Fatalf("unexpected password length of %d in %s", len(password), password)
-	}
-	firstHalf := password[:MinimumPasswordLength+testStrLen]
-	secondHalf := password[MinimumPasswordLength+testStrLen:]
-	if firstHalf == secondHalf {
-		t.Fatalf("%s should have differing passwords in each %s field", password, pwdFieldTmpl)
+	password, err = GeneratePassword("hello{{PASSWORD}}worldhello{{PASSWORD}}world", minimumLengthOfComplexString)
+	if err == nil {
+		t.Fatal("should have an error because there are multiple pwd template fields")
 	}
 }


### PR DESCRIPTION
Armon asked:
>Can we allow a Sprintf style format string to be provided that we populate with random characters? That seems more flexible, and lets users work around a custom filter.

This PR adds that feature. TODO update corresponding docs in Vault.