### PR TITLE
Add an endpoint to rotate root credentials

### DIFF
--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -66,6 +66,7 @@ type secretsClient interface {
 	Get(conf *ldaputil.ConfigEntry, serviceAccountName string) (*client.Entry, error)
 	GetPasswordLastSet(conf *ldaputil.ConfigEntry, serviceAccountName string) (time.Time, error)
 	UpdatePassword(conf *ldaputil.ConfigEntry, serviceAccountName string, newPassword string) error
+	UpdateRootPassword(conf *ldaputil.ConfigEntry, bindDN string, newPassword string) error
 }
 
 const backendHelp = `

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -32,6 +32,7 @@ func newBackend(client secretsClient) *backend {
 			adBackend.pathRoles(),
 			adBackend.pathListRoles(),
 			adBackend.pathCreds(),
+			adBackend.pathRotateCredentials(),
 		},
 		PathsSpecial: &logical.Paths{
 			SealWrapStorage: []string{

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -50,6 +50,9 @@ func TestBackend(t *testing.T) {
 
 	// Exercise all cred endpoints.
 	t.Run("read cred", ReadCred)
+
+	// Exercise root credential rotation.
+	t.Run("rotate root creds", RotateRootCreds)
 }
 
 func WriteConfig(t *testing.T) {
@@ -274,6 +277,21 @@ func ReadCred(t *testing.T) {
 	password := resp.Data["current_password"].(string)
 	if !strings.HasPrefix(password, util.PasswordComplexityPrefix) {
 		t.Fatalf("%s doesn't have the expected complexity prefix of %s", password, util.PasswordComplexityPrefix)
+	}
+}
+
+func RotateRootCreds(t *testing.T) {
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "rotate-root",
+		Storage:   testStorage,
+	}
+	resp, err := testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp != nil {
+		t.Fatal("expected no response because Vault generally doesn't return it for posts")
 	}
 }
 

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -282,7 +282,7 @@ func ReadCred(t *testing.T) {
 
 func RotateRootCreds(t *testing.T) {
 	req := &logical.Request{
-		Operation: logical.UpdateOperation,
+		Operation: logical.ReadOperation,
 		Path:      "rotate-root",
 		Storage:   testStorage,
 	}
@@ -348,5 +348,9 @@ func (f *fake) GetPasswordLastSet(conf *ldaputil.ConfigEntry, serviceAccountName
 }
 
 func (f *fake) UpdatePassword(conf *ldaputil.ConfigEntry, serviceAccountName string, newPassword string) error {
+	return nil
+}
+
+func (f *fake) UpdateRootPassword(conf *ldaputil.ConfigEntry, bindDN string, newPassword string) error {
 	return nil
 }

--- a/plugin/path_rotate_root_creds.go
+++ b/plugin/path_rotate_root_creds.go
@@ -12,7 +12,7 @@ func (b *backend) pathRotateCredentials() *framework.Path {
 	return &framework.Path{
 		Pattern: "rotate-root",
 		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.pathRotateCredentialsUpdate,
+			logical.ReadOperation: b.pathRotateCredentialsUpdate,
 		},
 
 		HelpSynopsis:    pathRotateCredentialsUpdateHelpSyn,
@@ -20,7 +20,7 @@ func (b *backend) pathRotateCredentials() *framework.Path {
 	}
 }
 
-func (b *backend) pathRotateCredentialsUpdate(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+func (b *backend) pathRotateCredentialsUpdate(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
 	engineConf, err := b.readConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func (b *backend) pathRotateCredentialsUpdate(ctx context.Context, req *logical.
 		return nil, err
 	}
 
-	if err := b.client.UpdatePassword(engineConf.ADConf, engineConf.ADConf.BindDN, newPassword); err != nil {
+	if err := b.client.UpdateRootPassword(engineConf.ADConf, engineConf.ADConf.BindDN, newPassword); err != nil {
 		return nil, err
 	}
 

--- a/plugin/path_rotate_root_creds.go
+++ b/plugin/path_rotate_root_creds.go
@@ -1,0 +1,60 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func (b *backend) pathRotateCredentials() *framework.Path {
+	return &framework.Path{
+		Pattern: "rotate-root",
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.UpdateOperation: b.pathRotateCredentialsUpdate,
+		},
+
+		HelpSynopsis:    pathRotateCredentialsUpdateHelpSyn,
+		HelpDescription: pathRotateCredentialsUpdateHelpDesc,
+	}
+}
+
+func (b *backend) pathRotateCredentialsUpdate(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+	engineConf, err := b.readConfig(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if engineConf == nil {
+		return nil, errors.New("the config is currently unset")
+	}
+
+	newPassword, err := util.GeneratePassword(engineConf.PasswordConf.Formatter, engineConf.PasswordConf.Length)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := b.client.UpdatePassword(engineConf.ADConf, engineConf.ADConf.BindDN, newPassword); err != nil {
+		return nil, err
+	}
+
+	engineConf.ADConf.BindPassword = newPassword
+	entry, err := logical.StorageEntryJSON(configStorageKey, engineConf)
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Storage.Put(ctx, entry); err != nil {
+		return nil, err
+	}
+
+	// Respond with a 204.
+	return nil, nil
+}
+
+const pathRotateCredentialsUpdateHelpSyn = `
+Request to rotate the root credentials.
+`
+
+const pathRotateCredentialsUpdateHelpDesc = `
+This path attempts to rotate the root credentials. 
+`

--- a/plugin/util/secrets_client.go
+++ b/plugin/util/secrets_client.go
@@ -71,3 +71,10 @@ func (c *SecretsClient) UpdatePassword(conf *ldaputil.ConfigEntry, serviceAccoun
 	}
 	return c.adClient.UpdatePassword(conf, filters, newPassword)
 }
+
+func (c *SecretsClient) UpdateRootPassword(conf *ldaputil.ConfigEntry, bindDN string, newPassword string) error {
+	filters := map[*client.Field][]string{
+		client.FieldRegistry.DistinguishedName: {bindDN},
+	}
+	return c.adClient.UpdatePassword(conf, filters, newPassword)
+}


### PR DESCRIPTION
Adds an MVP endpoint to rotate root credentials. 

There are two caveats to this that need to be documented:
- The `bind_dn` parameter must be specific enough that searching for it hits exactly one account
- There can be a delay for this to propagate the new password that the code has not yet mitigated, so if it were rotated during high-load times, it could result in a period of a second or more where all password rotations failed