### PR TITLE
Roll back if password unstored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ default: dev
 dev: fmtcheck generate
 	@CGO_ENABLED=0 BUILD_TAGS='$(BUILD_TAGS)' VAULT_DEV_BUILD=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 
+# testshort runs the quick unit tests and vets the code
+testshort: fmtcheck generate
+	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -short -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4
+
 # test runs the unit tests and vets the code
 test: fmtcheck generate
 	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -21,9 +21,10 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 
 func newBackend(client secretsClient) *backend {
 	adBackend := &backend{
-		client:    client,
-		roleCache: cache.New(roleCacheExpiration, roleCacheCleanup),
-		credCache: cache.New(credCacheExpiration, credCacheCleanup),
+		client:         client,
+		roleCache:      cache.New(roleCacheExpiration, roleCacheCleanup),
+		credCache:      cache.New(credCacheExpiration, credCacheCleanup),
+		rotateRootLock: new(int32),
 	}
 	adBackend.Backend = &framework.Backend{
 		Help: backendHelp,
@@ -51,9 +52,10 @@ type backend struct {
 
 	client secretsClient
 
-	roleCache *cache.Cache
-	credCache *cache.Cache
-	credLock  sync.Mutex
+	roleCache      *cache.Cache
+	credCache      *cache.Cache
+	credLock       sync.Mutex
+	rotateRootLock *int32
 }
 
 func (b *backend) Invalidate(ctx context.Context, key string) {

--- a/plugin/path_rotate_root_creds.go
+++ b/plugin/path_rotate_root_creds.go
@@ -50,7 +50,7 @@ func (b *backend) pathRotateCredentialsUpdate(ctx context.Context, req *logical.
 		// to roll any passwords, including our own to get back into a state of working. So, we need to roll back to
 		// the last password we successfully got into storage.
 		if rollbackErr := b.rollBackPassword(ctx, engineConf, oldPassword); rollbackErr != nil {
-			return nil, fmt.Errorf("unable to store new password due to %s and unable to return to previous password due to %s, configure a new binddn and bindpassword to restore active directory support", pwdStoringErr, rollbackErr)
+			return nil, fmt.Errorf("unable to store new password due to %s and unable to return to previous password due to %s, configure a new binddn and bindpass to restore active directory function", pwdStoringErr, rollbackErr)
 		}
 		return nil, fmt.Errorf("unable to update password due to storage err: %s", pwdStoringErr)
 	}

--- a/plugin/path_rotate_root_creds.go
+++ b/plugin/path_rotate_root_creds.go
@@ -40,9 +40,9 @@ func (b *backend) pathRotateCredentialsUpdate(ctx context.Context, req *logical.
 	oldPassword := engineConf.ADConf.BindPassword
 
 	if !atomic.CompareAndSwapInt32(b.rotateRootLock, 0, 1) {
-		b.Logger().Warn("rotate-root operation is already in progress")
-		// Respond with a 204 since this is not an error state.
-		return nil, nil
+		resp := &logical.Response{}
+		resp.AddWarning("Root password rotation is already in progress.")
+		return resp, nil
 	}
 	defer atomic.CompareAndSwapInt32(b.rotateRootLock, 1, 0)
 

--- a/plugin/path_rotate_root_creds.go
+++ b/plugin/path_rotate_root_creds.go
@@ -3,9 +3,12 @@ package plugin
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
+	"math"
+	"time"
 )
 
 func (b *backend) pathRotateCredentials() *framework.Path {
@@ -33,22 +36,60 @@ func (b *backend) pathRotateCredentialsUpdate(ctx context.Context, req *logical.
 	if err != nil {
 		return nil, err
 	}
+	oldPassword := engineConf.ADConf.BindPassword
 
+	// Update the password remotely.
 	if err := b.client.UpdateRootPassword(engineConf.ADConf, engineConf.ADConf.BindDN, newPassword); err != nil {
 		return nil, err
 	}
-
 	engineConf.ADConf.BindPassword = newPassword
-	entry, err := logical.StorageEntryJSON(configStorageKey, engineConf)
-	if err != nil {
-		return nil, err
-	}
-	if err := req.Storage.Put(ctx, entry); err != nil {
-		return nil, err
+
+	// Update the password locally.
+	if pwdStoringErr := storePassword(ctx, req, engineConf); pwdStoringErr != nil {
+		// We were unable to store the new password locally. We can't continue in this state because we won't be able
+		// to roll any passwords, including our own to get back into a state of working. So, we need to roll back to
+		// the last password we successfully got into storage.
+		if rollbackErr := b.rollBackPassword(ctx, engineConf, oldPassword); rollbackErr != nil {
+			return nil, fmt.Errorf("unable to store new password due to %s and unable to return to previous password due to %s, configure a new binddn and bindpassword to restore active directory support", pwdStoringErr, rollbackErr)
+		}
+		return nil, fmt.Errorf("unable to update password due to storage err: %s", pwdStoringErr)
 	}
 
 	// Respond with a 204.
 	return nil, nil
+}
+
+// rollBackPassword uses naive exponential backoff to retry updating to an old password,
+// because Active Directory may still be propagating the previous password change.
+func (b *backend) rollBackPassword(ctx context.Context, engineConf *configuration, oldPassword string) error {
+	var err error
+	for i := 0; i < 10; i++ {
+		waitSeconds := math.Pow(float64(i), 2)
+		timer := time.NewTimer(time.Duration(waitSeconds) * time.Second)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			// Outer environment is closing.
+			return fmt.Errorf("unable to roll back password because enclosing environment is shutting down")
+		}
+		if err = b.client.UpdateRootPassword(engineConf.ADConf, engineConf.ADConf.BindDN, oldPassword); err == nil {
+			// Success.
+			return nil
+		}
+	}
+	// Failure after looping.
+	return err
+}
+
+func storePassword(ctx context.Context, req *logical.Request, engineConf *configuration) error {
+	entry, err := logical.StorageEntryJSON(configStorageKey, engineConf)
+	if err != nil {
+		return err
+	}
+	if err := req.Storage.Put(ctx, entry); err != nil {
+		return err
+	}
+	return nil
 }
 
 const pathRotateCredentialsUpdateHelpSyn = `

--- a/plugin/path_rotate_root_creds_test.go
+++ b/plugin/path_rotate_root_creds_test.go
@@ -14,10 +14,8 @@ func TestRollBackPassword(t *testing.T) {
 	}
 
 	b := testBackend
-
 	doneChan := make(chan struct{})
 	ctx := &testContext{doneChan}
-
 	testConf := &configuration{
 		ADConf: &ldaputil.ConfigEntry{
 			BindDN: "cats",

--- a/plugin/path_rotate_root_creds_test.go
+++ b/plugin/path_rotate_root_creds_test.go
@@ -1,0 +1,93 @@
+package plugin
+
+import (
+	"github.com/go-errors/errors"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
+	"github.com/hashicorp/vault/helper/ldaputil"
+	"testing"
+	"time"
+)
+
+func TestRollBackPassword(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	b := testBackend
+
+	doneChan := make(chan struct{})
+	ctx := &testContext{doneChan}
+
+	testConf := &configuration{
+		ADConf: &ldaputil.ConfigEntry{
+			BindDN: "cats",
+		},
+	}
+
+	// Test succeeds immediately with successful response.
+	if err := b.rollBackPassword(ctx, testConf, "testing"); err != nil {
+		t.Fatal(err)
+	}
+
+	b.client = &badFake{}
+
+	// Test can be that retrying can be interrupted after 10 seconds using ctx.
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		b.rollBackPassword(ctx, testConf, "testing")
+	}()
+
+	// Wait 30 seconds and then close the doneChan, which should cause rollback to stop.
+	timer := time.NewTimer(time.Second * 30)
+	select {
+	case <-timer.C:
+		close(doneChan)
+	}
+
+	timer.Reset(time.Second)
+	select {
+	case <-timer.C:
+		t.Fatal("should have stopped by now")
+	case <-stopped:
+		// pass
+	}
+}
+
+type testContext struct {
+	doneChan chan struct{}
+}
+
+func (c *testContext) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}
+
+func (c *testContext) Done() <-chan struct{} {
+	return c.doneChan
+}
+
+func (c *testContext) Err() error {
+	return nil
+}
+
+func (c *testContext) Value(key interface{}) interface{} {
+	return nil
+}
+
+type badFake struct{}
+
+func (f *badFake) Get(conf *ldaputil.ConfigEntry, serviceAccountName string) (*client.Entry, error) {
+	return nil, errors.New("nope")
+}
+
+func (f *badFake) GetPasswordLastSet(conf *ldaputil.ConfigEntry, serviceAccountName string) (time.Time, error) {
+	return time.Time{}, errors.New("nope")
+}
+
+func (f *badFake) UpdatePassword(conf *ldaputil.ConfigEntry, serviceAccountName string, newPassword string) error {
+	return errors.New("nope")
+}
+
+func (f *badFake) UpdateRootPassword(conf *ldaputil.ConfigEntry, bindDN string, newPassword string) error {
+	return errors.New("nope")
+}


### PR DESCRIPTION
If a new root password can't be stored, attempts to roll back the remote AD servers to the old password.