### PR TITLE
Try old password during rotation period

### DIFF
--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
-	"github.com/hashicorp/vault/helper/ldaputil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 	"github.com/patrickmn/go-cache"
@@ -65,10 +64,10 @@ func (b *backend) Invalidate(ctx context.Context, key string) {
 
 // Wraps the *util.SecretsClient in an interface to support testing.
 type secretsClient interface {
-	Get(conf *ldaputil.ConfigEntry, serviceAccountName string) (*client.Entry, error)
-	GetPasswordLastSet(conf *ldaputil.ConfigEntry, serviceAccountName string) (time.Time, error)
-	UpdatePassword(conf *ldaputil.ConfigEntry, serviceAccountName string, newPassword string) error
-	UpdateRootPassword(conf *ldaputil.ConfigEntry, bindDN string, newPassword string) error
+	Get(conf *client.ADConf, serviceAccountName string) (*client.Entry, error)
+	GetPasswordLastSet(conf *client.ADConf, serviceAccountName string) (time.Time, error)
+	UpdatePassword(conf *client.ADConf, serviceAccountName string, newPassword string) error
+	UpdateRootPassword(conf *client.ADConf, bindDN string, newPassword string) error
 }
 
 const backendHelp = `

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-ldap/ldap"
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
-	"github.com/hashicorp/vault/helper/ldaputil"
 	"github.com/hashicorp/vault/logical"
 )
 
@@ -334,7 +333,7 @@ Beq3QOqp2+dga36IzQybzPQ8QtotrpSJ3q82zztEvyWiJ7E=
 
 type fake struct{}
 
-func (f *fake) Get(conf *ldaputil.ConfigEntry, serviceAccountName string) (*client.Entry, error) {
+func (f *fake) Get(conf *client.ADConf, serviceAccountName string) (*client.Entry, error) {
 	entry := &ldap.Entry{}
 	entry.Attributes = append(entry.Attributes, &ldap.EntryAttribute{
 		Name:   client.FieldRegistry.PasswordLastSet.String(),
@@ -343,14 +342,14 @@ func (f *fake) Get(conf *ldaputil.ConfigEntry, serviceAccountName string) (*clie
 	return client.NewEntry(entry), nil
 }
 
-func (f *fake) GetPasswordLastSet(conf *ldaputil.ConfigEntry, serviceAccountName string) (time.Time, error) {
+func (f *fake) GetPasswordLastSet(conf *client.ADConf, serviceAccountName string) (time.Time, error) {
 	return time.Time{}, nil
 }
 
-func (f *fake) UpdatePassword(conf *ldaputil.ConfigEntry, serviceAccountName string, newPassword string) error {
+func (f *fake) UpdatePassword(conf *client.ADConf, serviceAccountName string, newPassword string) error {
 	return nil
 }
 
-func (f *fake) UpdateRootPassword(conf *ldaputil.ConfigEntry, bindDN string, newPassword string) error {
+func (f *fake) UpdateRootPassword(conf *client.ADConf, bindDN string, newPassword string) error {
 	return nil
 }

--- a/plugin/client/client.go
+++ b/plugin/client/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/go-errors/errors"
 	"github.com/go-ldap/ldap"
@@ -25,7 +26,7 @@ type Client struct {
 	ldap *ldaputil.Client
 }
 
-func (c *Client) Search(cfg *ldaputil.ConfigEntry, filters map[*Field][]string) ([]*Entry, error) {
+func (c *Client) Search(cfg *ADConf, filters map[*Field][]string) ([]*Entry, error) {
 	req := &ldap.SearchRequest{
 		BaseDN:    cfg.UserDN,
 		Scope:     ldap.ScopeWholeSubtree,
@@ -33,7 +34,7 @@ func (c *Client) Search(cfg *ldaputil.ConfigEntry, filters map[*Field][]string) 
 		SizeLimit: math.MaxInt32,
 	}
 
-	conn, err := c.ldap.DialLDAP(cfg)
+	conn, err := c.ldap.DialLDAP(cfg.ConfigEntry)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +56,7 @@ func (c *Client) Search(cfg *ldaputil.ConfigEntry, filters map[*Field][]string) 
 	return entries, nil
 }
 
-func (c *Client) UpdateEntry(cfg *ldaputil.ConfigEntry, filters map[*Field][]string, newValues map[*Field][]string) error {
+func (c *Client) UpdateEntry(cfg *ADConf, filters map[*Field][]string, newValues map[*Field][]string) error {
 	entries, err := c.Search(cfg, filters)
 	if err != nil {
 		return err
@@ -72,7 +73,7 @@ func (c *Client) UpdateEntry(cfg *ldaputil.ConfigEntry, filters map[*Field][]str
 		modifyReq.Replace(field.String(), vals)
 	}
 
-	conn, err := c.ldap.DialLDAP(cfg)
+	conn, err := c.ldap.DialLDAP(cfg.ConfigEntry)
 	if err != nil {
 		return err
 	}
@@ -88,7 +89,7 @@ func (c *Client) UpdateEntry(cfg *ldaputil.ConfigEntry, filters map[*Field][]str
 // Active Directory doesn't recognize the passwordModify method.
 // See https://github.com/go-ldap/ldap/issues/106
 // for more.
-func (c *Client) UpdatePassword(cfg *ldaputil.ConfigEntry, filters map[*Field][]string, newPassword string) error {
+func (c *Client) UpdatePassword(cfg *ADConf, filters map[*Field][]string, newPassword string) error {
 	pwdEncoded, err := formatPassword(newPassword)
 	if err != nil {
 		return err
@@ -119,15 +120,47 @@ func toString(filters map[*Field][]string) string {
 	return "(" + result + ")"
 }
 
-func bind(cfg *ldaputil.ConfigEntry, conn ldaputil.Connection) error {
+func bind(cfg *ADConf, conn ldaputil.Connection) error {
 	if cfg.BindPassword == "" {
 		return errors.New("unable to bind due to lack of configured password")
 	}
+
 	if cfg.UPNDomain != "" {
-		return conn.Bind(fmt.Sprintf("%s@%s", ldaputil.EscapeLDAPValue(cfg.BindDN), cfg.UPNDomain), cfg.BindPassword)
+		origErr := conn.Bind(fmt.Sprintf("%s@%s", ldaputil.EscapeLDAPValue(cfg.BindDN), cfg.UPNDomain), cfg.BindPassword)
+		if origErr == nil {
+			return nil
+		}
+		if !shouldTryLastPwd(cfg.LastBindPasswordRotation) {
+			return origErr
+		}
+		if err := conn.Bind(fmt.Sprintf("%s@%s", ldaputil.EscapeLDAPValue(cfg.BindDN), cfg.UPNDomain), cfg.LastBindPassword); err != nil {
+			// Return the original error because it'll be more helpful for debugging.
+			return origErr
+		}
+		return nil
 	}
+
 	if cfg.BindDN != "" {
-		return conn.Bind(cfg.BindDN, cfg.BindPassword)
+		origErr := conn.Bind(cfg.BindDN, cfg.BindPassword)
+		if origErr == nil {
+			return nil
+		}
+		if !shouldTryLastPwd(cfg.LastBindPasswordRotation) {
+			return origErr
+		}
+		if err := conn.Bind(cfg.BindDN, cfg.LastBindPassword); err != nil {
+			// Return the original error because it'll be more helpful for debugging.
+			return origErr
+		}
 	}
 	return errors.New("must provide binddn or upndomain")
+}
+
+// shouldTryLastPwd determines if we should try a previous password.
+// Active Directory can return a variety of errors when a password is invalid.
+// Rather than attempting to catalogue these errors across multiple versions of
+// AD, we simply try the last password if it's been less than a set amount of
+// time since a rotation occurred.
+func shouldTryLastPwd(lastBindPasswordRotation time.Time) bool {
+	return lastBindPasswordRotation.Add(10 * time.Minute).After(time.Now())
 }

--- a/plugin/client/client.go
+++ b/plugin/client/client.go
@@ -130,7 +130,7 @@ func bind(cfg *ADConf, conn ldaputil.Connection) error {
 		if origErr == nil {
 			return nil
 		}
-		if !shouldTryLastPwd(cfg.LastBindPasswordRotation) {
+		if !shouldTryLastPwd(cfg.LastBindPassword, cfg.LastBindPasswordRotation) {
 			return origErr
 		}
 		if err := conn.Bind(fmt.Sprintf("%s@%s", ldaputil.EscapeLDAPValue(cfg.BindDN), cfg.UPNDomain), cfg.LastBindPassword); err != nil {
@@ -145,7 +145,7 @@ func bind(cfg *ADConf, conn ldaputil.Connection) error {
 		if origErr == nil {
 			return nil
 		}
-		if !shouldTryLastPwd(cfg.LastBindPasswordRotation) {
+		if !shouldTryLastPwd(cfg.LastBindPassword, cfg.LastBindPasswordRotation) {
 			return origErr
 		}
 		if err := conn.Bind(cfg.BindDN, cfg.LastBindPassword); err != nil {
@@ -161,6 +161,12 @@ func bind(cfg *ADConf, conn ldaputil.Connection) error {
 // Rather than attempting to catalogue these errors across multiple versions of
 // AD, we simply try the last password if it's been less than a set amount of
 // time since a rotation occurred.
-func shouldTryLastPwd(lastBindPasswordRotation time.Time) bool {
+func shouldTryLastPwd(lastPwd string, lastBindPasswordRotation time.Time) bool {
+	if lastPwd == "" {
+		return false
+	}
+	if lastBindPasswordRotation.Equal(time.Time{}) {
+		return false
+	}
 	return lastBindPasswordRotation.Add(10 * time.Minute).After(time.Now())
 }

--- a/plugin/client/client_test.go
+++ b/plugin/client/client_test.go
@@ -137,12 +137,15 @@ func TestUpdatePassword(t *testing.T) {
 	}
 }
 
-func emptyConfig() *ldaputil.ConfigEntry {
-	return &ldaputil.ConfigEntry{
-		UserDN:       "dc=example,dc=com",
-		Url:          "ldap://127.0.0.1",
-		BindDN:       "cats",
-		BindPassword: "cats",
+// TODO need to test forwards and backwards jsonification
+func emptyConfig() *ADConf {
+	return &ADConf{
+		ConfigEntry: &ldaputil.ConfigEntry{
+			UserDN:       "dc=example,dc=com",
+			Url:          "ldap://127.0.0.1",
+			BindDN:       "cats",
+			BindPassword: "cats",
+		},
 	}
 }
 

--- a/plugin/client/client_test.go
+++ b/plugin/client/client_test.go
@@ -137,7 +137,6 @@ func TestUpdatePassword(t *testing.T) {
 	}
 }
 
-// TODO need to test forwards and backwards jsonification
 func emptyConfig() *ADConf {
 	return &ADConf{
 		ConfigEntry: &ldaputil.ConfigEntry{

--- a/plugin/client/config.go
+++ b/plugin/client/config.go
@@ -1,12 +1,13 @@
 package client
 
 import (
-	"github.com/hashicorp/vault/helper/ldaputil"
 	"time"
+
+	"github.com/hashicorp/vault/helper/ldaputil"
 )
 
 type ADConf struct {
 	*ldaputil.ConfigEntry
-	LastBindPassword         string
-	LastBindPasswordRotation time.Time
+	LastBindPassword         string    `json:"last_bind_password"`
+	LastBindPasswordRotation time.Time `json:"last_bind_password_rotation"`
 }

--- a/plugin/client/config.go
+++ b/plugin/client/config.go
@@ -1,0 +1,12 @@
+package client
+
+import (
+	"github.com/hashicorp/vault/helper/ldaputil"
+	"time"
+)
+
+type ADConf struct {
+	*ldaputil.ConfigEntry
+	LastBindPassword         string
+	LastBindPasswordRotation time.Time
+}

--- a/plugin/client/tools/simplecall.go
+++ b/plugin/client/tools/simplecall.go
@@ -40,15 +40,17 @@ func main() {
 	}
 }
 
-func newInsecureConfig() *ldaputil.ConfigEntry {
-	return &ldaputil.ConfigEntry{
-		UserDN:        dn,
-		Certificate:   "",
-		InsecureTLS:   true,
-		BindPassword:  password,
-		TLSMinVersion: "tls12",
-		TLSMaxVersion: "tls12",
-		Url:           rawURL,
-		BindDN:        username,
+func newInsecureConfig() *client.ADConf {
+	return &client.ADConf{
+		ConfigEntry: &ldaputil.ConfigEntry{
+			UserDN:        dn,
+			Certificate:   "",
+			InsecureTLS:   true,
+			BindPassword:  password,
+			TLSMinVersion: "tls12",
+			TLSMaxVersion: "tls12",
+			Url:           rawURL,
+			BindDN:        username,
+		},
 	}
 }

--- a/plugin/engineconf.go
+++ b/plugin/engineconf.go
@@ -1,10 +1,10 @@
 package plugin
 
 import (
-	"github.com/hashicorp/vault/helper/ldaputil"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
 )
 
 type configuration struct {
 	PasswordConf *passwordConf
-	ADConf       *ldaputil.ConfigEntry
+	ADConf       *client.ADConf
 }

--- a/plugin/engineconf_test.go
+++ b/plugin/engineconf_test.go
@@ -1,0 +1,89 @@
+package plugin
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// These json snippets are only used in our internal storage,
+// they aren't presented externally.
+const (
+	samplePreviousConfJson = `{
+	  "PasswordConf": {
+		"ttl": 1,
+		"max_ttl": 1,
+		"length": 1,
+		"formatter": "something"
+	  },
+	  "ADConf": {
+		"url": "www.somewhere.com",
+		"userdn": "userdn",
+		"groupdn": "groupdn",
+		"groupfilter": "groupFilter",
+		"groupattr": "groupattr",
+		"upndomain": "upndomain",
+		"userattr": "",
+		"certificate": "",
+		"insecure_tls": false,
+		"starttls": false,
+		"binddn": "",
+		"bindpass": "",
+		"deny_null_bind": false,
+		"discoverdn": false,
+		"tls_min_version": "",
+		"tls_max_version": ""
+	  }
+	}`
+
+	sampleCurrentConfJson = `{
+	  "PasswordConf": {
+		"ttl": 1,
+		"max_ttl": 1,
+		"length": 1,
+		"formatter": "something"
+	  },
+	  "ADConf": {
+		"url": "www.somewhere.com",
+		"userdn": "userdn",
+		"groupdn": "groupdn",
+		"groupfilter": "groupFilter",
+		"groupattr": "groupattr",
+		"upndomain": "upndomain",
+		"userattr": "",
+		"certificate": "",
+		"insecure_tls": false,
+		"starttls": false,
+		"binddn": "",
+		"bindpass": "",
+		"deny_null_bind": false,
+		"discoverdn": false,
+		"tls_min_version": "",
+		"tls_max_version": "",
+		"last_bind_password": "foo"
+	  }
+	}`
+)
+
+func TestCanUnmarshalPreviousConfig(t *testing.T) {
+	testConf := &configuration{}
+	if err := json.NewDecoder(bytes.NewReader([]byte(samplePreviousConfJson))).Decode(testConf); err != nil {
+		t.Fatal(err)
+	}
+	if testConf.PasswordConf.Formatter != "something" {
+		t.Fatal("test failed to unmarshal password conf")
+	}
+	if testConf.ADConf.Url != "www.somewhere.com" {
+		t.Fatal("test failed to unmarshal active directory client conf")
+	}
+}
+
+func TestCanUnmarshalNewConfig(t *testing.T) {
+	testConf := &configuration{}
+	if err := json.NewDecoder(bytes.NewReader([]byte(sampleCurrentConfJson))).Decode(testConf); err != nil {
+		t.Fatal(err)
+	}
+	if testConf.ADConf.LastBindPassword != "foo" {
+		t.Fatal("test failed to unmarshal bind password information")
+	}
+}

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
 	"github.com/hashicorp/vault/helper/ldaputil"
 	"github.com/hashicorp/vault/logical"
@@ -30,7 +31,7 @@ func (b *backend) readConfig(ctx context.Context, storage logical.Storage) (*con
 	if entry == nil {
 		return nil, nil
 	}
-	config := &configuration{&passwordConf{}, &ldaputil.ConfigEntry{}}
+	config := &configuration{&passwordConf{}, &client.ADConf{}}
 	if err := entry.DecodeJSON(config); err != nil {
 		return nil, err
 	}
@@ -115,7 +116,7 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 		Formatter: formatter,
 	}
 
-	config := &configuration{passwordConf, activeDirectoryConf}
+	config := &configuration{passwordConf, &client.ADConf{ConfigEntry: activeDirectoryConf}}
 	entry, err := logical.StorageEntryJSON(configStorageKey, config)
 	if err != nil {
 		return nil, err

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
@@ -152,6 +153,9 @@ func (b *backend) configReadOperation(ctx context.Context, req *logical.Request,
 		"upndomain":       config.ADConf.UPNDomain,
 		"tls_min_version": config.ADConf.TLSMinVersion,
 		"tls_max_version": config.ADConf.TLSMaxVersion,
+	}
+	if !config.ADConf.LastBindPasswordRotation.Equal(time.Time{}) {
+		configMap["last_bind_password_rotation"] = config.ADConf.LastBindPasswordRotation
 	}
 	for k, v := range config.PasswordConf.Map() {
 		configMap[k] = v

--- a/plugin/path_rotate_root_creds_test.go
+++ b/plugin/path_rotate_root_creds_test.go
@@ -17,8 +17,10 @@ func TestRollBackPassword(t *testing.T) {
 	doneChan := make(chan struct{})
 	ctx := &testContext{doneChan}
 	testConf := &configuration{
-		ADConf: &ldaputil.ConfigEntry{
-			BindDN: "cats",
+		ADConf: &client.ADConf{
+			ConfigEntry: &ldaputil.ConfigEntry{
+				BindDN: "cats",
+			},
 		},
 	}
 
@@ -74,18 +76,18 @@ func (c *testContext) Value(key interface{}) interface{} {
 
 type badFake struct{}
 
-func (f *badFake) Get(conf *ldaputil.ConfigEntry, serviceAccountName string) (*client.Entry, error) {
+func (f *badFake) Get(conf *client.ADConf, serviceAccountName string) (*client.Entry, error) {
 	return nil, errors.New("nope")
 }
 
-func (f *badFake) GetPasswordLastSet(conf *ldaputil.ConfigEntry, serviceAccountName string) (time.Time, error) {
+func (f *badFake) GetPasswordLastSet(conf *client.ADConf, serviceAccountName string) (time.Time, error) {
 	return time.Time{}, errors.New("nope")
 }
 
-func (f *badFake) UpdatePassword(conf *ldaputil.ConfigEntry, serviceAccountName string, newPassword string) error {
+func (f *badFake) UpdatePassword(conf *client.ADConf, serviceAccountName string, newPassword string) error {
 	return errors.New("nope")
 }
 
-func (f *badFake) UpdateRootPassword(conf *ldaputil.ConfigEntry, bindDN string, newPassword string) error {
+func (f *badFake) UpdateRootPassword(conf *client.ADConf, bindDN string, newPassword string) error {
 	return errors.New("nope")
 }

--- a/plugin/util/secrets_client.go
+++ b/plugin/util/secrets_client.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
-	"github.com/hashicorp/vault/helper/ldaputil"
 )
 
 func NewSecretsClient(logger hclog.Logger) *SecretsClient {
@@ -18,7 +17,7 @@ type SecretsClient struct {
 	adClient *client.Client
 }
 
-func (c *SecretsClient) Get(conf *ldaputil.ConfigEntry, serviceAccountName string) (*client.Entry, error) {
+func (c *SecretsClient) Get(conf *client.ADConf, serviceAccountName string) (*client.Entry, error) {
 	filters := map[*client.Field][]string{
 		client.FieldRegistry.UserPrincipalName: {serviceAccountName},
 	}
@@ -37,7 +36,7 @@ func (c *SecretsClient) Get(conf *ldaputil.ConfigEntry, serviceAccountName strin
 	return entries[0], nil
 }
 
-func (c *SecretsClient) GetPasswordLastSet(conf *ldaputil.ConfigEntry, serviceAccountName string) (time.Time, error) {
+func (c *SecretsClient) GetPasswordLastSet(conf *client.ADConf, serviceAccountName string) (time.Time, error) {
 	entry, err := c.Get(conf, serviceAccountName)
 	if err != nil {
 		return time.Time{}, err
@@ -65,14 +64,14 @@ func (c *SecretsClient) GetPasswordLastSet(conf *ldaputil.ConfigEntry, serviceAc
 	return t, nil
 }
 
-func (c *SecretsClient) UpdatePassword(conf *ldaputil.ConfigEntry, serviceAccountName string, newPassword string) error {
+func (c *SecretsClient) UpdatePassword(conf *client.ADConf, serviceAccountName string, newPassword string) error {
 	filters := map[*client.Field][]string{
 		client.FieldRegistry.UserPrincipalName: {serviceAccountName},
 	}
 	return c.adClient.UpdatePassword(conf, filters, newPassword)
 }
 
-func (c *SecretsClient) UpdateRootPassword(conf *ldaputil.ConfigEntry, bindDN string, newPassword string) error {
+func (c *SecretsClient) UpdateRootPassword(conf *client.ADConf, bindDN string, newPassword string) error {
 	filters := map[*client.Field][]string{
 		client.FieldRegistry.DistinguishedName: {bindDN},
 	}


### PR DESCRIPTION
If the `rotate-root` endpoint changes the master password we're using to rotate all passwords, there can be a period of 1 or more seconds where the new password is propagating to all instances. During that time, if the `creds/:roleName` endpoint attempts to generate new credentials, it'll be hit and miss which password it should use - the old one, or the new one.

This PR adds code where if there's an error binding it tries the last master password if it was rotated within the last 10 minutes. This avoids attempting to catalogue the ways a password rotation error may present across different Active Directory implementations.