### PR TITLE
Return respErr

### DIFF
--- a/plugin/path_creds.go
+++ b/plugin/path_creds.go
@@ -141,10 +141,7 @@ func (b *backend) credReadOperation(ctx context.Context, req *logical.Request, f
 		}
 	}
 	if respErr != nil {
-		return nil, err
-	}
-	if resp == nil {
-		return nil, nil
+		return nil, respErr
 	}
 	return resp, nil
 }


### PR DESCRIPTION
The wrong error was being return causing failures to occur without any useful errors.