### PR TITLE
Fix test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ testshort: fmtcheck generate
 
 # test runs the unit tests and vets the code
 test: fmtcheck generate
-	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4
+	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -v -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4
 
 testcompile: fmtcheck generate
 	@for pkg in $(TEST) ; do \

--- a/plugin/role_test.go
+++ b/plugin/role_test.go
@@ -85,24 +85,3 @@ func TestTTLTooHigh(t *testing.T) {
 		t.Fatal("should error when ttl is too high")
 	}
 }
-
-func TestNegativeTTL(t *testing.T) {
-	passwordConf := &passwordConf{
-		TTL:    10,
-		MaxTTL: maxTTLInt,
-		Length: defaultPasswordLength,
-	}
-
-	fieldData := &framework.FieldData{
-		Raw: map[string]interface{}{
-			"service_account_name": "kibana@example.com",
-			"ttl": -100,
-		},
-		Schema: schema,
-	}
-
-	_, err := getValidatedTTL(passwordConf, fieldData)
-	if err == nil {
-		t.Fatal("should error then ttl is negative")
-	}
-}


### PR DESCRIPTION
This test is triggering a panic, and it's no longer needed. Basically, if you pass in a negative value for a TTL, Vault will panic, and this behavior is intentional.