### PR TITLE
Fixes from testing

### DIFF
--- a/plugin/path_creds_test.go
+++ b/plugin/path_creds_test.go
@@ -1,0 +1,118 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-ldap/ldap"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func Test_TTLIsRespected(t *testing.T) {
+	fakeClient := &thisFake{}
+	b := newBackend(fakeClient)
+	ctx := context.Background()
+	storage := &logical.InmemStorage{}
+	logger := hclog.Default()
+	logger.SetLevel(hclog.Debug)
+
+	if err := b.Setup(ctx, &logical.BackendConfig{
+		Logger: logger,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up the config
+	config := &configuration{
+		PasswordConf: &passwordConf{
+			/*
+				This differs from the original config posted by the user
+				but I have to do it to get a matching TTL on the role.
+			*/
+			TTL:    7776000,
+			MaxTTL: 7776000,
+			Length: 14,
+		},
+		ADConf: &client.ADConf{},
+	}
+	entry, err := logical.StorageEntryJSON(configStorageKey, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.Put(ctx, entry); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up the role
+	createRoleReq := &logical.Request{
+		Storage: storage,
+	}
+	createRoleFieldData := &framework.FieldData{
+		Schema: b.pathRoles().Fields,
+		Raw: map[string]interface{}{
+			"name":                 "test-role",
+			"service_account_name": "vault_test2@aaa.bbb.ccc.com",
+			"ttl":                  7776000, // This also differs from the original role posted.
+		},
+	}
+
+	_, err = b.roleUpdateOperation(ctx, createRoleReq, createRoleFieldData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get creds the first time
+	readCredsFieldData := &framework.FieldData{
+		Schema: b.pathCreds().Fields,
+		Raw: map[string]interface{}{
+			"name": "test-role",
+		},
+	}
+	readCredsReq := &logical.Request{
+		Storage: storage,
+	}
+	_, err = b.credReadOperation(ctx, readCredsReq, readCredsFieldData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get creds another time
+	_, err = b.credReadOperation(ctx, readCredsReq, readCredsFieldData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fakeClient.numPasswordUpdates > 1 {
+		t.Fatalf("expected 1 password update but received %d", fakeClient.numPasswordUpdates)
+	}
+}
+
+type thisFake struct {
+	numPasswordUpdates int
+}
+
+func (f *thisFake) Get(conf *client.ADConf, serviceAccountName string) (*client.Entry, error) {
+	entry := &ldap.Entry{}
+	entry.Attributes = append(entry.Attributes, &ldap.EntryAttribute{
+		Name:   client.FieldRegistry.PasswordLastSet.String(),
+		Values: []string{"131680504285591921"},
+	})
+	return client.NewEntry(entry), nil
+}
+
+func (f *thisFake) GetPasswordLastSet(conf *client.ADConf, serviceAccountName string) (time.Time, error) {
+	f.numPasswordUpdates++
+	return time.Date(2019, time.April, 17, 23, 10, 58, 0, time.UTC), nil
+}
+
+func (f *thisFake) UpdatePassword(conf *client.ADConf, serviceAccountName string, newPassword string) error {
+	return nil
+}
+
+func (f *thisFake) UpdateRootPassword(conf *client.ADConf, bindDN string, newPassword string) error {
+	return nil
+}

--- a/plugin/path_roles.go
+++ b/plugin/path_roles.go
@@ -108,7 +108,7 @@ func (b *backend) readRole(ctx context.Context, storage logical.Storage, roleNam
 	return role, nil
 }
 
-func (b *backend) writeRole(ctx context.Context, storage logical.Storage, roleName string, role *backendRole) error {
+func (b *backend) writeRoleToStorage(ctx context.Context, storage logical.Storage, roleName string, role *backendRole) error {
 	entry, err := logical.StorageEntryJSON(roleStorageKey+"/"+roleName, role)
 	if err != nil {
 		return err
@@ -116,7 +116,8 @@ func (b *backend) writeRole(ctx context.Context, storage logical.Storage, roleNa
 	if err := storage.Put(ctx, entry); err != nil {
 		return err
 	}
-	b.roleCache.SetDefault(roleName, role)
+	// Invalidate the cache.
+	b.roleCache.Delete(roleName)
 	return nil
 }
 
@@ -163,8 +164,9 @@ func (b *backend) roleUpdateOperation(ctx context.Context, req *logical.Request,
 		}
 	}
 
-	// writeRole it to storage and the roleCache.
-	if err := b.writeRole(ctx, req.Storage, roleName, role); err != nil {
+	// writeRoleToStorage it to storage, but not to the role cache because its
+	// last updated time from AD is only grabbed on reads.
+	if err := b.writeRoleToStorage(ctx, req.Storage, roleName, role); err != nil {
 		return nil, err
 	}
 

--- a/plugin/util/passwords.go
+++ b/plugin/util/passwords.go
@@ -35,7 +35,7 @@ func ValidatePwdSettings(formatter string, totalLength int) error {
 	// Check for if there's no formatter.
 	if formatter == "" {
 		if totalLength < len(PasswordComplexityPrefix)+minimumLengthOfComplexString {
-			return fmt.Errorf("it's not possible to generate a _secure_ password of length %d, please boost length to %d, though Vault recommends higher", totalLength, minimumLengthOfComplexString)
+			return fmt.Errorf("it's not possible to generate a _secure_ password of length %d, please boost length to %d, though Vault recommends higher", totalLength, minimumLengthOfComplexString+len(PasswordComplexityPrefix))
 		}
 		return nil
 	}


### PR DESCRIPTION
In writing a test for https://github.com/hashicorp/vault/issues/6476, I found a couple of things, though I was unable to duplicate the fast-rolling behavior for that ticket:

- On first role read, the date for the password last having been updated in Active Directory was blank. This was because I was caching roles before having performed that check, so I fixed it by always invalidating the cache when a role is written to storage, and letting the caller cache the role if appropriate.
- Some debug output reported that the password was being rotated when actually, it was just being pulled, rotated if needed, and returned. That debug output is corrected.
- An error message was reporting that the minimum password length needed to be 8, when it actually needed to be 14. Fixes that.
- Adds a test that aims to duplicate the linked issue; however, the test currently doesn't show multiple password rotations. Adding the test and if the user comes back with different settings to duplicate the issue, will update the test.