### PR TITLE
Make time buffer configurable

### DIFF
--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -60,12 +60,13 @@ func WriteConfig(t *testing.T) {
 		Path:      configPath,
 		Storage:   testStorage,
 		Data: map[string]interface{}{
-			"binddn":      "tester",
-			"password":    "pa$$w0rd",
-			"url":         "ldap://138.91.247.105",
-			"certificate": validCertificate,
-			"userdn":      "dc=example,dc=com",
-			"formatter":   "mycustom{{PASSWORD}}",
+			"binddn":                       "tester",
+			"password":                     "pa$$w0rd",
+			"url":                          "ldap://138.91.247.105",
+			"certificate":                  validCertificate,
+			"userdn":                       "dc=example,dc=com",
+			"formatter":                    "mycustom{{PASSWORD}}",
+			"out_of_band_rotation_seconds": 5,
 		},
 	}
 	resp, err := testBackend.HandleRequest(testCtx, req)
@@ -131,6 +132,10 @@ func ReadConfig(t *testing.T) {
 
 	if resp.Data["formatter"] != "mycustom{{PASSWORD}}" {
 		t.Fatalf("received unexpected formatter of \"%d\"", resp.Data["formatter"])
+	}
+
+	if resp.Data["out_of_band_rotation_seconds"] != 5 {
+		t.Fatalf(`received unexpected seconds of %d`, resp.Data["out_of_band_rotation_seconds"])
 	}
 }
 

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -60,13 +60,13 @@ func WriteConfig(t *testing.T) {
 		Path:      configPath,
 		Storage:   testStorage,
 		Data: map[string]interface{}{
-			"binddn":                       "tester",
-			"password":                     "pa$$w0rd",
-			"url":                          "ldap://138.91.247.105",
-			"certificate":                  validCertificate,
-			"userdn":                       "dc=example,dc=com",
-			"formatter":                    "mycustom{{PASSWORD}}",
-			"out_of_band_rotation_seconds": 5,
+			"binddn":                  "tester",
+			"password":                "pa$$w0rd",
+			"url":                     "ldap://138.91.247.105",
+			"certificate":             validCertificate,
+			"userdn":                  "dc=example,dc=com",
+			"formatter":               "mycustom{{PASSWORD}}",
+			"last_rotation_tolerance": 10,
 		},
 	}
 	resp, err := testBackend.HandleRequest(testCtx, req)
@@ -134,8 +134,8 @@ func ReadConfig(t *testing.T) {
 		t.Fatalf("received unexpected formatter of \"%d\"", resp.Data["formatter"])
 	}
 
-	if resp.Data["out_of_band_rotation_seconds"] != 5 {
-		t.Fatalf(`received unexpected seconds of %d`, resp.Data["out_of_band_rotation_seconds"])
+	if resp.Data["last_rotation_tolerance"] != 10 {
+		t.Fatalf(`received unexpected seconds of %d`, resp.Data["last_rotation_tolerance"])
 	}
 }
 

--- a/plugin/engineconf.go
+++ b/plugin/engineconf.go
@@ -5,6 +5,7 @@ import (
 )
 
 type configuration struct {
-	PasswordConf *passwordConf
-	ADConf       *client.ADConf
+	PasswordConf          *passwordConf
+	ADConf                *client.ADConf
+	PasswordLastSetBuffer int
 }

--- a/plugin/engineconf.go
+++ b/plugin/engineconf.go
@@ -7,5 +7,5 @@ import (
 type configuration struct {
 	PasswordConf          *passwordConf
 	ADConf                *client.ADConf
-	PasswordLastSetBuffer int
+	LastRotationTolerance int
 }

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -72,10 +72,10 @@ func (b *backend) configFields() map[string]*framework.FieldSchema {
 		Type:        framework.TypeString,
 		Description: `Text to insert the password into, ex. "customPrefix{{PASSWORD}}customSuffix".`,
 	}
-	fields["out_of_band_rotation_seconds"] = &framework.FieldSchema{
+	fields["last_rotation_tolerance"] = &framework.FieldSchema{
 		Type:        framework.TypeDurationSecond,
 		Description: "The number of seconds after a Vault rotation where, if Active Directory shows a later rotation, it should be considered out-of-band.",
-		Default:     1,
+		Default:     5,
 	}
 	return fields
 }
@@ -95,7 +95,7 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 	maxTTL := fieldData.Get("max_ttl").(int)
 	length := fieldData.Get("length").(int)
 	formatter := fieldData.Get("formatter").(string)
-	passwordLastSetBuffer := fieldData.Get("out_of_band_rotation_seconds").(int)
+	lastRotationTolerance := fieldData.Get("last_rotation_tolerance").(int)
 
 	if ttl == 0 {
 		ttl = int(b.System().DefaultLeaseTTL().Seconds())
@@ -123,7 +123,7 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 		Formatter: formatter,
 	}
 
-	config := &configuration{passwordConf, &client.ADConf{ConfigEntry: activeDirectoryConf}, passwordLastSetBuffer}
+	config := &configuration{passwordConf, &client.ADConf{ConfigEntry: activeDirectoryConf}, lastRotationTolerance}
 	entry, err := logical.StorageEntryJSON(configStorageKey, config)
 	if err != nil {
 		return nil, err
@@ -150,16 +150,16 @@ func (b *backend) configReadOperation(ctx context.Context, req *logical.Request,
 	// as we lean away from returning sensitive information unless it's absolutely necessary.
 	// Also, we don't return the full ADConf here because not all parameters are used by this engine.
 	configMap := map[string]interface{}{
-		"url":                          config.ADConf.Url,
-		"starttls":                     config.ADConf.StartTLS,
-		"insecure_tls":                 config.ADConf.InsecureTLS,
-		"certificate":                  config.ADConf.Certificate,
-		"binddn":                       config.ADConf.BindDN,
-		"userdn":                       config.ADConf.UserDN,
-		"upndomain":                    config.ADConf.UPNDomain,
-		"tls_min_version":              config.ADConf.TLSMinVersion,
-		"tls_max_version":              config.ADConf.TLSMaxVersion,
-		"out_of_band_rotation_seconds": config.PasswordLastSetBuffer,
+		"url":                     config.ADConf.Url,
+		"starttls":                config.ADConf.StartTLS,
+		"insecure_tls":            config.ADConf.InsecureTLS,
+		"certificate":             config.ADConf.Certificate,
+		"binddn":                  config.ADConf.BindDN,
+		"userdn":                  config.ADConf.UserDN,
+		"upndomain":               config.ADConf.UPNDomain,
+		"tls_min_version":         config.ADConf.TLSMinVersion,
+		"tls_max_version":         config.ADConf.TLSMaxVersion,
+		"last_rotation_tolerance": config.LastRotationTolerance,
 	}
 	if !config.ADConf.LastBindPasswordRotation.Equal(time.Time{}) {
 		configMap["last_bind_password_rotation"] = config.ADConf.LastBindPasswordRotation

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -150,15 +150,16 @@ func (b *backend) configReadOperation(ctx context.Context, req *logical.Request,
 	// as we lean away from returning sensitive information unless it's absolutely necessary.
 	// Also, we don't return the full ADConf here because not all parameters are used by this engine.
 	configMap := map[string]interface{}{
-		"url":             config.ADConf.Url,
-		"starttls":        config.ADConf.StartTLS,
-		"insecure_tls":    config.ADConf.InsecureTLS,
-		"certificate":     config.ADConf.Certificate,
-		"binddn":          config.ADConf.BindDN,
-		"userdn":          config.ADConf.UserDN,
-		"upndomain":       config.ADConf.UPNDomain,
-		"tls_min_version": config.ADConf.TLSMinVersion,
-		"tls_max_version": config.ADConf.TLSMaxVersion,
+		"url":                          config.ADConf.Url,
+		"starttls":                     config.ADConf.StartTLS,
+		"insecure_tls":                 config.ADConf.InsecureTLS,
+		"certificate":                  config.ADConf.Certificate,
+		"binddn":                       config.ADConf.BindDN,
+		"userdn":                       config.ADConf.UserDN,
+		"upndomain":                    config.ADConf.UPNDomain,
+		"tls_min_version":              config.ADConf.TLSMinVersion,
+		"tls_max_version":              config.ADConf.TLSMaxVersion,
+		"out_of_band_rotation_seconds": config.PasswordLastSetBuffer,
 	}
 	if !config.ADConf.LastBindPasswordRotation.Equal(time.Time{}) {
 		configMap["last_bind_password_rotation"] = config.ADConf.LastBindPasswordRotation

--- a/plugin/path_creds.go
+++ b/plugin/path_creds.go
@@ -16,18 +16,6 @@ const (
 	credPrefix = "creds/"
 	storageKey = "creds"
 
-	// Since Active Directory offers eventual consistency, in testing we found that sometimes
-	// Active Directory returned "password last set" times that were _later_ than our own,
-	// even though ours were captured after synchronously completing a password update operation.
-	//
-	// An example we captured was:
-	// 		last_vault_rotation     2018-04-18T22:29:57.385454779Z
-	// 		password_last_set       2018-04-18T22:29:57.3902786Z
-	//
-	// Thus we add a short time buffer when checking whether anyone _else_ updated the AD password
-	// since Vault last rotated it.
-	passwordLastSetBuffer = time.Second
-
 	// Since password TTL can be set to as low as 1 second,
 	// we can't cache passwords for an entire second.
 	credCacheCleanup    = time.Second / 3
@@ -71,6 +59,14 @@ func (b *backend) pathCreds() *framework.Path {
 func (b *backend) credReadOperation(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
 	cred := make(map[string]interface{})
 
+	engineConf, err := b.readConfig(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if engineConf == nil {
+		return nil, errors.New("the config is currently unset")
+	}
+
 	roleName := fieldData.Get("name").(string)
 
 	// We act upon quite a few things below that could be racy if not locked:
@@ -99,14 +95,14 @@ func (b *backend) credReadOperation(ctx context.Context, req *logical.Request, f
 
 	case role.LastVaultRotation == unset:
 		b.Logger().Debug("rotating password for the first time so Vault will know it")
-		resp, respErr = b.generateAndReturnCreds(ctx, req.Storage, roleName, role, cred)
+		resp, respErr = b.generateAndReturnCreds(ctx, engineConf, req.Storage, roleName, role, cred)
 
-	case role.PasswordLastSet.After(role.LastVaultRotation.Add(passwordLastSetBuffer)):
+	case role.PasswordLastSet.After(role.LastVaultRotation.Add(time.Second * time.Duration(engineConf.PasswordLastSetBuffer))):
 		b.Logger().Debug(fmt.Sprintf(
 			"Vault rotated the password at %s, but it was rotated in AD later at %s, so rotating it again so Vault will know it",
 			role.LastVaultRotation.String(), role.PasswordLastSet.String()),
 		)
-		resp, respErr = b.generateAndReturnCreds(ctx, req.Storage, roleName, role, cred)
+		resp, respErr = b.generateAndReturnCreds(ctx, engineConf, req.Storage, roleName, role, cred)
 
 	default:
 		b.Logger().Debug("determining whether to rotate credential")
@@ -139,7 +135,7 @@ func (b *backend) credReadOperation(ctx context.Context, req *logical.Request, f
 				"last Vault rotation was at %s, and since the TTL is %d and it's now %s, it's time to rotate it",
 				role.LastVaultRotation.String(), role.TTL, now.String()),
 			)
-			resp, respErr = b.generateAndReturnCreds(ctx, req.Storage, roleName, role, cred)
+			resp, respErr = b.generateAndReturnCreds(ctx, engineConf, req.Storage, roleName, role, cred)
 		} else {
 			b.Logger().Debug("returning previous credential")
 			resp = &logical.Response{
@@ -153,15 +149,7 @@ func (b *backend) credReadOperation(ctx context.Context, req *logical.Request, f
 	return resp, nil
 }
 
-func (b *backend) generateAndReturnCreds(ctx context.Context, storage logical.Storage, roleName string, role *backendRole, previousCred map[string]interface{}) (*logical.Response, error) {
-	engineConf, err := b.readConfig(ctx, storage)
-	if err != nil {
-		return nil, err
-	}
-	if engineConf == nil {
-		return nil, errors.New("the config is currently unset")
-	}
-
+func (b *backend) generateAndReturnCreds(ctx context.Context, engineConf *configuration, storage logical.Storage, roleName string, role *backendRole, previousCred map[string]interface{}) (*logical.Response, error) {
 	newPassword, err := util.GeneratePassword(engineConf.PasswordConf.Formatter, engineConf.PasswordConf.Length)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This solves the issue [here](https://github.com/hashicorp/vault/issues/6476) where a user was seeing Vault rotate passwords every time because their Active Directory cluster took _over_ a second to perpetuate the new password to all instances. Then Vault would see that the password was rotated _after_ it rotated it, and would re-rotate it to get back into sync. This situation was expected, but the time buffer for considering it in need of rotation was hard-coded as 1 second.

In reality, the amount of time it takes will correlate with the size of each Active Directory cluster, so this PR makes the time buffer configurable, now defaulting to 5 seconds to cover all environments we've seen so far.