### PR TITLE
Make readConfig a static function

### DIFF
--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -24,7 +24,7 @@ const (
 	defaultTLSVersion = "tls12"
 )
 
-func (b *backend) readConfig(ctx context.Context, storage logical.Storage) (*configuration, error) {
+func readConfig(ctx context.Context, storage logical.Storage) (*configuration, error) {
 	entry, err := storage.Get(ctx, configStorageKey)
 	if err != nil {
 		return nil, err
@@ -145,7 +145,7 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 }
 
 func (b *backend) configReadOperation(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
-	config, err := b.readConfig(ctx, req.Storage)
+	config, err := readConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -16,7 +16,7 @@ var (
 func TestCacheReader(t *testing.T) {
 
 	// we should start with no config
-	config, err := testBackend.readConfig(ctx, storage)
+	config, err := readConfig(ctx, storage)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestCacheReader(t *testing.T) {
 	}
 
 	// now that we've updated the config, we should be able to configReadOperation it
-	config, err = testBackend.readConfig(ctx, storage)
+	config, err = readConfig(ctx, storage)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestCacheReader(t *testing.T) {
 	}
 
 	// now that we've deleted the config, it should be unset again
-	config, err = testBackend.readConfig(ctx, storage)
+	config, err = readConfig(ctx, storage)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugin/path_creds.go
+++ b/plugin/path_creds.go
@@ -59,7 +59,7 @@ func (b *backend) pathCreds() *framework.Path {
 func (b *backend) credReadOperation(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
 	cred := make(map[string]interface{})
 
-	engineConf, err := b.readConfig(ctx, req.Storage)
+	engineConf, err := readConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/path_roles.go
+++ b/plugin/path_roles.go
@@ -89,7 +89,7 @@ func (b *backend) readRole(ctx context.Context, storage logical.Storage, roleNam
 	}
 
 	// Always check when ActiveDirectory shows the password as last set on the fly.
-	engineConf, err := b.readConfig(ctx, storage)
+	engineConf, err := readConfig(ctx, storage)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func (b *backend) roleUpdateOperation(ctx context.Context, req *logical.Request,
 	// Get everything we need to construct the role.
 	roleName := fieldData.Get("name").(string)
 
-	engineConf, err := b.readConfig(ctx, req.Storage)
+	engineConf, err := readConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/path_rotate_root_creds.go
+++ b/plugin/path_rotate_root_creds.go
@@ -25,7 +25,7 @@ func (b *backend) pathRotateCredentials() *framework.Path {
 }
 
 func (b *backend) pathRotateCredentialsUpdate(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
-	engineConf, err := b.readConfig(ctx, req.Storage)
+	engineConf, err := readConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR converts `readConfig` to a static function so it'll be easier to reuse in areas where the entire back-end may not be available. In beginning work on this code, I know this will be needed so I'm breaking it into a very small and easy to read PR.