### PR TITLE
Add password handler

### DIFF
--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -40,8 +40,9 @@ func newBackend(client secretsClient) *backend {
 				credPrefix,
 			},
 		},
-		Invalidate:  adBackend.Invalidate,
-		BackendType: logical.TypeLogical,
+		Invalidate:   adBackend.Invalidate,
+		BackendType:  logical.TypeLogical,
+		PeriodicFunc: retryFailedPasswordUpdates(client),
 	}
 	return adBackend
 }

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -23,7 +24,7 @@ var (
 				MaxLeaseTTLVal:     maxLeaseTTLVal,
 			},
 		}
-		b := newBackend(&fake{})
+		b := newBackend(&fakeSecretsClient{})
 		b.Setup(context.Background(), conf)
 		return b
 	}()
@@ -336,25 +337,43 @@ Beq3QOqp2+dga36IzQybzPQ8QtotrpSJ3q82zztEvyWiJ7E=
 -----END CERTIFICATE-----
 `
 
-type fake struct{}
+type fakeSecretsClient struct {
+	throwErrs bool
+}
 
-func (f *fake) Get(conf *client.ADConf, serviceAccountName string) (*client.Entry, error) {
+func (f *fakeSecretsClient) Get(conf *client.ADConf, serviceAccountName string) (*client.Entry, error) {
 	entry := &ldap.Entry{}
 	entry.Attributes = append(entry.Attributes, &ldap.EntryAttribute{
 		Name:   client.FieldRegistry.PasswordLastSet.String(),
 		Values: []string{"131680504285591921"},
 	})
-	return client.NewEntry(entry), nil
+	var err error
+	if f.throwErrs {
+		err = errors.New("nope")
+	}
+	return client.NewEntry(entry), err
 }
 
-func (f *fake) GetPasswordLastSet(conf *client.ADConf, serviceAccountName string) (time.Time, error) {
-	return time.Time{}, nil
+func (f *fakeSecretsClient) GetPasswordLastSet(conf *client.ADConf, serviceAccountName string) (time.Time, error) {
+	var err error
+	if f.throwErrs {
+		err = errors.New("nope")
+	}
+	return time.Time{}, err
 }
 
-func (f *fake) UpdatePassword(conf *client.ADConf, serviceAccountName string, newPassword string) error {
-	return nil
+func (f *fakeSecretsClient) UpdatePassword(conf *client.ADConf, serviceAccountName string, newPassword string) error {
+	var err error
+	if f.throwErrs {
+		err = errors.New("nope")
+	}
+	return err
 }
 
-func (f *fake) UpdateRootPassword(conf *client.ADConf, bindDN string, newPassword string) error {
-	return nil
+func (f *fakeSecretsClient) UpdateRootPassword(conf *client.ADConf, bindDN string, newPassword string) error {
+	var err error
+	if f.throwErrs {
+		err = errors.New("nope")
+	}
+	return err
 }

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-ldap/ldap"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -24,7 +25,10 @@ var (
 				MaxLeaseTTLVal:     maxLeaseTTLVal,
 			},
 		}
-		b := newBackend(&fakeSecretsClient{})
+		b, _ := newBackend(testCtx, &logical.BackendConfig{
+			StorageView: testStorage,
+			Logger:      hclog.NewNullLogger(),
+		}, &fakeSecretsClient{})
 		b.Setup(context.Background(), conf)
 		return b
 	}()

--- a/plugin/checkout_handlers.go
+++ b/plugin/checkout_handlers.go
@@ -3,6 +3,8 @@ package plugin
 import (
 	"context"
 	"errors"
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
+	"github.com/hashicorp/vault/sdk/framework"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/logical"
@@ -22,6 +24,124 @@ type CheckOutHandler interface {
 	CheckIn(ctx context.Context, storage logical.Storage, serviceAccountName string) error
 	Delete(ctx context.Context, storage logical.Storage, serviceAccountName string) error
 	Status(ctx context.Context, storage logical.Storage, serviceAccountName string) (*CheckOut, error)
+}
+
+type PasswordHandler struct {
+	client secretsClient
+	child  CheckOutHandler
+}
+
+func (h *PasswordHandler) CheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error {
+	// Nothing needs to be done with passwords when they're being checked out.
+	return h.child.CheckOut(ctx, storage, serviceAccountName, checkOut)
+}
+
+func (h *PasswordHandler) CheckIn(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	// On check-ins, a new AD password is generated, updated in AD, and stored.
+	engineConf, err := readConfig(ctx, storage)
+	if err != nil {
+		return err
+	}
+	if engineConf == nil {
+		return errors.New("the config is currently unset")
+	}
+	newPassword, err := util.GeneratePassword(engineConf.PasswordConf.Formatter, engineConf.PasswordConf.Length)
+	if err != nil {
+		return err
+	}
+	// In case any of this fails, place a WAL about what we intend to do so we can retry.
+	walID, err := framework.PutWAL(ctx, storage, "password-update", map[string]string{
+		"service_account_name": serviceAccountName,
+		"new_password":         newPassword,
+	})
+	if err != nil {
+		return err
+	}
+	if err := h.client.UpdatePassword(engineConf.ADConf, serviceAccountName, newPassword); err != nil {
+		return err
+	}
+	entry, err := logical.StorageEntryJSON("password/"+serviceAccountName, newPassword)
+	if err != nil {
+		return err
+	}
+	if err := storage.Put(ctx, entry); err != nil {
+		return err
+	}
+	// We have succeeded, we don't need the WAL anymore.
+	if err := framework.DeleteWAL(ctx, storage, walID); err != nil {
+		return err
+	}
+	return h.child.CheckIn(ctx, storage, serviceAccountName)
+}
+
+func (h *PasswordHandler) Delete(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	if err := storage.Delete(ctx, "password/"+serviceAccountName); err != nil {
+		return err
+	}
+	return h.child.Delete(ctx, storage, serviceAccountName)
+}
+
+func (h *PasswordHandler) Status(ctx context.Context, storage logical.Storage, serviceAccountName string) (*CheckOut, error) {
+	return h.child.Status(ctx, storage, serviceAccountName)
+}
+
+// retrievePassword is a utility function for grabbing a service account's password from storage.
+func retrievePassword(ctx context.Context, storage logical.Storage, serviceAccountName string) (string, error) {
+	entry, err := storage.Get(ctx, "password/"+serviceAccountName)
+	if err != nil {
+		return "", err
+	}
+	if entry == nil {
+		return "", nil
+	}
+	password := ""
+	if err := entry.DecodeJSON(&password); err != nil {
+		return "", err
+	}
+	return password, nil
+}
+
+// retryFailedPasswordUpdates is a callback because we need to add a client to the mix.
+func retryFailedPasswordUpdates(client secretsClient) func(context.Context, *logical.Request) error {
+	return func(ctx context.Context, req *logical.Request) error {
+		engineConf, err := readConfig(ctx, req.Storage)
+		if err != nil {
+			return err
+		}
+		if engineConf == nil {
+			return errors.New("the config is currently unset")
+		}
+
+		walIDs, err := framework.ListWAL(ctx, req.Storage)
+		if err != nil {
+			return err
+		}
+		for _, walID := range walIDs {
+			walEntry, err := framework.GetWAL(ctx, req.Storage, walID)
+			if err != nil {
+				return err
+			}
+			passwordUpdate := walEntry.Data.(map[string]interface{})
+			serviceAccountName := passwordUpdate["service_account_name"].(string)
+			newPassword := passwordUpdate["new_password"].(string)
+
+			if err := client.UpdatePassword(engineConf.ADConf, serviceAccountName, newPassword); err != nil {
+				return err
+			}
+			entry, err := logical.StorageEntryJSON("password/"+serviceAccountName, newPassword)
+			if err != nil {
+				return err
+			}
+			if err := req.Storage.Put(ctx, entry); err != nil {
+				return err
+			}
+			// We have succeeded, we don't need the WAL anymore.
+			if err := framework.DeleteWAL(ctx, req.Storage, walID); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 }
 
 type StorageHandler struct{}

--- a/plugin/checkout_handlers.go
+++ b/plugin/checkout_handlers.go
@@ -3,10 +3,10 @@ package plugin
 import (
 	"context"
 	"errors"
-	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
-	"github.com/hashicorp/vault/sdk/framework"
 	"time"
 
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
+	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 

--- a/plugin/checkout_handlers_test.go
+++ b/plugin/checkout_handlers_test.go
@@ -7,21 +7,38 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func Test_StorageHandler(t *testing.T) {
-	// Construct everything we'll need for our tests.
+func setup() (context.Context, logical.Storage, string, *CheckOut) {
 	ctx := context.Background()
 	storage := &logical.InmemStorage{}
 	serviceAccountName := "becca@example.com"
-	testTime := time.Now().UTC()
-	testCheckOut := &CheckOut{
+	checkOut := &CheckOut{
 		BorrowerEntityID:    "entity-id",
 		BorrowerClientToken: "client-token",
 		LendingPeriod:       10,
-		Due:                 testTime,
+		Due:                 time.Now().UTC(),
 	}
+	config := &configuration{
+		PasswordConf: &passwordConf{
+			Length: 14,
+		},
+	}
+	entry, err := logical.StorageEntryJSON(configStorageKey, config)
+	if err != nil {
+		panic(err)
+	}
+	if err := storage.Put(ctx, entry); err != nil {
+		panic(err)
+	}
+	return ctx, storage, serviceAccountName, checkOut
+}
+
+func Test_StorageHandler(t *testing.T) {
+	ctx, storage, serviceAccountName, testCheckOut := setup()
+
 	storageHandler := &StorageHandler{}
 
 	// If we try to check something out for the first time, it should succeed.
@@ -91,4 +108,127 @@ func Test_StorageHandler(t *testing.T) {
 	if err := storageHandler.Delete(ctx, storage, serviceAccountName); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestPasswordHandlerInterfaceFulfillment(t *testing.T) {
+	ctx, storage, serviceAccountName, checkOut := setup()
+
+	passwordHandler := &PasswordHandler{
+		client: &fakeSecretsClient{},
+		child:  &fakeCheckOutHandler{},
+	}
+
+	// There should be no error during check-out.
+	if err := passwordHandler.CheckOut(ctx, storage, serviceAccountName, checkOut); err != nil {
+		t.Fatal(err)
+	}
+
+	// The password should get rotated successfully during check-in.
+	origPassword, err := retrievePassword(ctx, storage, serviceAccountName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if origPassword != "" {
+		t.Fatal("expected empty password")
+	}
+	if err := passwordHandler.CheckIn(ctx, storage, serviceAccountName); err != nil {
+		t.Fatal(err)
+	}
+	currPassword, err := retrievePassword(ctx, storage, serviceAccountName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if currPassword == origPassword {
+		t.Fatal("expected new password, but received none")
+	}
+
+	// There should be no error during delete and the password should be deleted.
+	if err := passwordHandler.Delete(ctx, storage, serviceAccountName); err != nil {
+		t.Fatal(err)
+	}
+
+	// There should be no error during status.
+	currPassword, err = retrievePassword(ctx, storage, serviceAccountName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if currPassword != "" {
+		t.Fatal("expected empty password")
+	}
+	checkOut, err = passwordHandler.Status(ctx, storage, serviceAccountName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkOut != nil {
+		t.Fatal("expected checkOut to be nil")
+	}
+}
+
+func TestPasswordHandlerWALHandling(t *testing.T) {
+	ctx, storage, _, _ := setup()
+
+	// First, try to do a bunch of password updates but throw an error whenever we try to reach AD.
+	testServiceAccountNames := []string{
+		"a@example.com",
+		"b@example.com",
+		"c@example.com",
+	}
+	passwordHandler := &PasswordHandler{
+		client: &fakeSecretsClient{throwErrs: true},
+		child:  &fakeCheckOutHandler{},
+	}
+
+	for _, serviceAccountName := range testServiceAccountNames {
+		if err := passwordHandler.CheckIn(ctx, storage, serviceAccountName); err == nil {
+			t.Fatal("expected err")
+		}
+	}
+
+	// We should now have 3 WAL entries.
+	walIDs, err := framework.ListWAL(ctx, storage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(walIDs) != len(testServiceAccountNames) {
+		t.Fatal("expected there to be one WAL for each service account whose password we couldn't update")
+	}
+
+	// Now retry them with a non-error-throwing secrets client to simulate that transient errs
+	// have ceased.
+	retryFunc := retryFailedPasswordUpdates(&fakeSecretsClient{})
+	if err := retryFunc(ctx, &logical.Request{Storage: storage}); err != nil {
+		t.Fatal(err)
+	}
+
+	// We should now have 0 WAL entries.
+	walIDs, err = framework.ListWAL(ctx, storage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(walIDs) != 0 {
+		t.Fatal("expected there to be no further WALs")
+	}
+
+	// We should have no errors when the retry func runs without anything to do.
+	if err := retryFunc(ctx, &logical.Request{Storage: storage}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type fakeCheckOutHandler struct{}
+
+func (f *fakeCheckOutHandler) CheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error {
+	return nil
+}
+
+func (f *fakeCheckOutHandler) CheckIn(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	return nil
+}
+
+func (f *fakeCheckOutHandler) Delete(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	return nil
+}
+
+func (f *fakeCheckOutHandler) Status(ctx context.Context, storage logical.Storage, serviceAccountName string) (*CheckOut, error) {
+	return nil, nil
 }

--- a/plugin/checkout_handlers_test.go
+++ b/plugin/checkout_handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -195,7 +196,7 @@ func TestPasswordHandlerWALHandling(t *testing.T) {
 
 	// Now retry them with a non-error-throwing secrets client to simulate that transient errs
 	// have ceased.
-	retryFunc := retryFailedPasswordUpdates(&fakeSecretsClient{})
+	retryFunc := retryFailedPasswordUpdates(hclog.NewNullLogger(), &fakeSecretsClient{})
 	if err := retryFunc(ctx, &logical.Request{Storage: storage}); err != nil {
 		t.Fatal(err)
 	}

--- a/plugin/path_creds_test.go
+++ b/plugin/path_creds_test.go
@@ -14,9 +14,12 @@ import (
 
 func Test_TTLIsRespected(t *testing.T) {
 	fakeClient := &thisFake{}
-	b := newBackend(fakeClient)
 	ctx := context.Background()
 	storage := &logical.InmemStorage{}
+	b, _ := newBackend(ctx, &logical.BackendConfig{
+		StorageView: storage,
+		Logger:      hclog.NewNullLogger(),
+	}, fakeClient)
 	logger := hclog.Default()
 	logger.SetLevel(hclog.Debug)
 


### PR DESCRIPTION
This PR adds a password rotation handler for the AD credential checkout feature.

Whenever we attempt to update a password, a write-ahead-log (WAL) is first placed to show our intention. If the update succeeds, the WAL is deleted. If it fails, it's left behind. Then, each minute, the `PeriodicFunc` (`retryFailedPasswordUpdates`) is run. It checks for any outstanding WALs and re-attempts to execute the operation. Also, anytime a new server is coming up as the leader, we check for and delete any outstanding WALs.