### PR TITLE
Add password handler

### DIFF
--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -14,7 +14,9 @@ import (
 
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
 	backend := newBackend(util.NewSecretsClient(conf.Logger))
-	backend.Setup(ctx, conf)
+	if err := backend.Setup(ctx, conf); err != nil {
+		return nil, err
+	}
 	return backend, nil
 }
 

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -23,7 +24,7 @@ var (
 				MaxLeaseTTLVal:     maxLeaseTTLVal,
 			},
 		}
-		b := newBackend(&fake{})
+		b := newBackend(&fakeSecretsClient{})
 		b.Setup(context.Background(), conf)
 		return b
 	}()
@@ -336,25 +337,43 @@ Beq3QOqp2+dga36IzQybzPQ8QtotrpSJ3q82zztEvyWiJ7E=
 -----END CERTIFICATE-----
 `
 
-type fake struct{}
+type fakeSecretsClient struct {
+	throwErrs bool
+}
 
-func (f *fake) Get(conf *client.ADConf, serviceAccountName string) (*client.Entry, error) {
+func (f *fakeSecretsClient) Get(conf *client.ADConf, serviceAccountName string) (*client.Entry, error) {
 	entry := &ldap.Entry{}
 	entry.Attributes = append(entry.Attributes, &ldap.EntryAttribute{
 		Name:   client.FieldRegistry.PasswordLastSet.String(),
 		Values: []string{"131680504285591921"},
 	})
-	return client.NewEntry(entry), nil
+	var err error
+	if f.throwErrs {
+		err = errors.New("nope")
+	}
+	return client.NewEntry(entry), err
 }
 
-func (f *fake) GetPasswordLastSet(conf *client.ADConf, serviceAccountName string) (time.Time, error) {
-	return time.Time{}, nil
+func (f *fakeSecretsClient) GetPasswordLastSet(conf *client.ADConf, serviceAccountName string) (time.Time, error) {
+	var err error
+	if f.throwErrs {
+		err = errors.New("nope")
+	}
+	return time.Time{}, err
 }
 
-func (f *fake) UpdatePassword(conf *client.ADConf, serviceAccountName string, newPassword string) error {
-	return nil
+func (f *fakeSecretsClient) UpdatePassword(conf *client.ADConf, serviceAccountName string, newPassword string) error {
+	var err error
+	if f.throwErrs {
+		err = errors.New("nope")
+	}
+	return err
 }
 
-func (f *fake) UpdateRootPassword(conf *client.ADConf, bindDN string, newPassword string) error {
-	return nil
+func (f *fakeSecretsClient) UpdateRootPassword(conf *client.ADConf, bindDN string, newPassword string) error {
+	var err error
+	if f.throwErrs {
+		err = errors.New("nope")
+	}
+	return err
 }

--- a/plugin/checkout_handlers.go
+++ b/plugin/checkout_handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -41,6 +42,87 @@ type CheckOutHandler interface {
 	//  - A nil *CheckOut and nil error if the serviceAccountName is not currently checked out.
 	//  - A nil *CheckOut and populated err if the state cannot be determined.
 	Status(ctx context.Context, storage logical.Storage, serviceAccountName string) (*CheckOut, error)
+
+	// Delete cleans up anything we were tracking from the service account that we will no longer need.
+	Delete(ctx context.Context, storage logical.Storage, serviceAccountName string) error
+}
+
+// PasswordHandler is responsible for rolling and storing a service account's password upon check-in.
+type PasswordHandler struct {
+	client secretsClient
+	child  CheckOutHandler
+}
+
+// CheckOut requires no further action from the password handler other than passing along the request.
+func (h *PasswordHandler) CheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error {
+	return h.child.CheckOut(ctx, storage, serviceAccountName, checkOut)
+}
+
+// CheckIn rotates the service account's password remotely and stores it locally.
+// If this process fails part-way through:
+// 		- An error will be returned.
+//		- The account will remain checked out.
+//		- The client may (or may not) retry the check-in.
+// 		- The overdue watcher will still check it in if its lending period runs out.
+func (h *PasswordHandler) CheckIn(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	if err := validateInputs(ctx, storage, serviceAccountName, nil, false); err != nil {
+		return err
+	}
+	// On check-ins, a new AD password is generated, updated in AD, and stored.
+	engineConf, err := readConfig(ctx, storage)
+	if err != nil {
+		return err
+	}
+	if engineConf == nil {
+		return errors.New("the config is currently unset")
+	}
+	newPassword, err := util.GeneratePassword(engineConf.PasswordConf.Formatter, engineConf.PasswordConf.Length)
+	if err != nil {
+		return err
+	}
+	if err := h.client.UpdatePassword(engineConf.ADConf, serviceAccountName, newPassword); err != nil {
+		return err
+	}
+	entry, err := logical.StorageEntryJSON("password/"+serviceAccountName, newPassword)
+	if err != nil {
+		return err
+	}
+	if err := storage.Put(ctx, entry); err != nil {
+		return err
+	}
+	return h.child.CheckIn(ctx, storage, serviceAccountName)
+}
+
+// Delete simply deletes the password from storage so it's not stored unnecessarily.
+func (h *PasswordHandler) Delete(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	if err := validateInputs(ctx, storage, serviceAccountName, nil, false); err != nil {
+		return err
+	}
+	if err := storage.Delete(ctx, "password/"+serviceAccountName); err != nil {
+		return err
+	}
+	return h.child.Delete(ctx, storage, serviceAccountName)
+}
+
+// Status doesn't need any password work.
+func (h *PasswordHandler) Status(ctx context.Context, storage logical.Storage, serviceAccountName string) (*CheckOut, error) {
+	return h.child.Status(ctx, storage, serviceAccountName)
+}
+
+// retrievePassword is a utility function for grabbing a service account's password from storage.
+func retrievePassword(ctx context.Context, storage logical.Storage, serviceAccountName string) (string, error) {
+	entry, err := storage.Get(ctx, "password/"+serviceAccountName)
+	if err != nil {
+		return "", err
+	}
+	if entry == nil {
+		return "", nil
+	}
+	password := ""
+	if err := entry.DecodeJSON(&password); err != nil {
+		return "", err
+	}
+	return password, nil
 }
 
 // StorageHandler's sole responsibility is to communicate with storage regarding check-outs.
@@ -71,11 +153,8 @@ func (h *StorageHandler) CheckOut(ctx context.Context, storage logical.Storage, 
 // CheckIn will return nil error if it was able to successfully check in an account.
 // If the account was already checked in, it still returns no error.
 func (h *StorageHandler) CheckIn(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
-	if err := validateInputs(ctx, storage, serviceAccountName, nil, false); err != nil {
-		return err
-	}
-	// We simply take checkouts out of storage when they're checked in.
-	return storage.Delete(ctx, checkoutStoragePrefix+serviceAccountName)
+	// We simply delete checkouts from storage when they're checked in.
+	return h.Delete(ctx, storage, serviceAccountName)
 }
 
 // Status returns either:
@@ -98,6 +177,13 @@ func (h *StorageHandler) Status(ctx context.Context, storage logical.Storage, se
 		return nil, err
 	}
 	return checkOut, nil
+}
+
+func (h *StorageHandler) Delete(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	if err := validateInputs(ctx, storage, serviceAccountName, nil, false); err != nil {
+		return err
+	}
+	return storage.Delete(ctx, checkoutStoragePrefix+serviceAccountName)
 }
 
 // validateInputs is a helper function for ensuring that a caller has satisfied all required arguments.

--- a/plugin/checkout_handlers_test.go
+++ b/plugin/checkout_handlers_test.go
@@ -10,18 +10,34 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func Test_StorageHandler(t *testing.T) {
-	// Construct everything we'll need for our tests.
+func setup() (context.Context, logical.Storage, string, *CheckOut) {
 	ctx := context.Background()
 	storage := &logical.InmemStorage{}
 	serviceAccountName := "becca@example.com"
-	testTime := time.Now().UTC()
-	testCheckOut := &CheckOut{
+	checkOut := &CheckOut{
 		BorrowerEntityID:    "entity-id",
 		BorrowerClientToken: "client-token",
 		LendingPeriod:       10,
-		Due:                 testTime,
+		Due:                 time.Now().UTC(),
 	}
+	config := &configuration{
+		PasswordConf: &passwordConf{
+			Length: 14,
+		},
+	}
+	entry, err := logical.StorageEntryJSON(configStorageKey, config)
+	if err != nil {
+		panic(err)
+	}
+	if err := storage.Put(ctx, entry); err != nil {
+		panic(err)
+	}
+	return ctx, storage, serviceAccountName, checkOut
+}
+
+func Test_StorageHandler(t *testing.T) {
+	ctx, storage, serviceAccountName, testCheckOut := setup()
+
 	storageHandler := &StorageHandler{}
 
 	// If we try to check something out for the first time, it should succeed.
@@ -75,10 +91,7 @@ func Test_StorageHandler(t *testing.T) {
 }
 
 func TestValidateInputs(t *testing.T) {
-	ctx := context.Background()
-	storage := &logical.InmemStorage{}
-	serviceAccountName := "some-name"
-	checkOut := &CheckOut{}
+	ctx, storage, serviceAccountName, checkOut := setup()
 
 	// Failure cases.
 	if err := validateInputs(nil, storage, serviceAccountName, checkOut, true); err == nil {
@@ -100,4 +113,76 @@ func TestValidateInputs(t *testing.T) {
 	if err := validateInputs(ctx, storage, serviceAccountName, nil, false); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestPasswordHandlerInterfaceFulfillment(t *testing.T) {
+	ctx, storage, serviceAccountName, checkOut := setup()
+
+	passwordHandler := &PasswordHandler{
+		client: &fakeSecretsClient{},
+		child:  &fakeCheckOutHandler{},
+	}
+
+	// There should be no error during check-out.
+	if err := passwordHandler.CheckOut(ctx, storage, serviceAccountName, checkOut); err != nil {
+		t.Fatal(err)
+	}
+
+	// The password should get rotated successfully during check-in.
+	origPassword, err := retrievePassword(ctx, storage, serviceAccountName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if origPassword != "" {
+		t.Fatal("expected empty password")
+	}
+	if err := passwordHandler.CheckIn(ctx, storage, serviceAccountName); err != nil {
+		t.Fatal(err)
+	}
+	currPassword, err := retrievePassword(ctx, storage, serviceAccountName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if currPassword == origPassword {
+		t.Fatal("expected new password, but received none")
+	}
+
+	// There should be no error during delete and the password should be deleted.
+	if err := passwordHandler.Delete(ctx, storage, serviceAccountName); err != nil {
+		t.Fatal(err)
+	}
+
+	// There should be no error during status.
+	currPassword, err = retrievePassword(ctx, storage, serviceAccountName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if currPassword != "" {
+		t.Fatal("expected empty password")
+	}
+	checkOut, err = passwordHandler.Status(ctx, storage, serviceAccountName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkOut != nil {
+		t.Fatal("expected checkOut to be nil")
+	}
+}
+
+type fakeCheckOutHandler struct{}
+
+func (f *fakeCheckOutHandler) CheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error {
+	return nil
+}
+
+func (f *fakeCheckOutHandler) CheckIn(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	return nil
+}
+
+func (f *fakeCheckOutHandler) Delete(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	return nil
+}
+
+func (f *fakeCheckOutHandler) Status(ctx context.Context, storage logical.Storage, serviceAccountName string) (*CheckOut, error) {
+	return nil, nil
 }

--- a/plugin/checkout_handlers_test.go
+++ b/plugin/checkout_handlers_test.go
@@ -129,12 +129,9 @@ func TestPasswordHandlerInterfaceFulfillment(t *testing.T) {
 	}
 
 	// The password should get rotated successfully during check-in.
-	origPassword, err := retrievePassword(ctx, storage, serviceAccountName)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if origPassword != "" {
-		t.Fatal("expected empty password")
+	_, err := retrievePassword(ctx, storage, serviceAccountName)
+	if err != ErrNotFound {
+		t.Fatal("expected ErrNotFound")
 	}
 	if err := passwordHandler.CheckIn(ctx, storage, serviceAccountName); err != nil {
 		t.Fatal(err)
@@ -143,8 +140,8 @@ func TestPasswordHandlerInterfaceFulfillment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if currPassword == origPassword {
-		t.Fatal("expected new password, but received none")
+	if currPassword == "" {
+		t.Fatal("expected password, but received none")
 	}
 
 	// There should be no error during delete and the password should be deleted.
@@ -152,13 +149,9 @@ func TestPasswordHandlerInterfaceFulfillment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// There should be no error during status.
 	currPassword, err = retrievePassword(ctx, storage, serviceAccountName)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if currPassword != "" {
-		t.Fatal("expected empty password")
+	if err != ErrNotFound {
+		t.Fatal("expected ErrNotFound")
 	}
 	checkOut, err = passwordHandler.Status(ctx, storage, serviceAccountName)
 	if err != nil {


### PR DESCRIPTION
Wrapping the storage handler in #41 will be a password handler, introduced in this PR, whose sole responsibility is to roll passwords upon check-in.

On the first iteration of this code, I considered various approaches to mid-update failure. I could use a WAL, or I could use a deferred func that rolls back the password in the face of failure. However, upon reflection, I decided against this for the following reasons:

- If we spin off a WAL log that will be used to attempt updating the password every minute, the user could actually call back and rotate the password in the meantime, or the lending period could end and the overdue watcher could check it in. 
- If that happened, it would actually be desirable.
- It probably would make the most cognitive sense to a user or application that if they believe their check-in attempt failed, it's failed; it probably doesn't make much sense that a background process is still attempting to check it in along with the user and other processes.

For that reason, I just error if we have mid-flight failures. Even if the password gets into an unknown state, it will still be okay because the account will still be reflected as checked out, and we can still send a new one when we're able to successfully check it in.