### PR TITLE
Add service account locker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           echo 'export GO111MODULE=on' >> $BASH_ENV
     - run:
         name: "Run Tests"
-        command: go test -v ./...
+        command: go test -v -race ./...
     - run:
         name: "Install Gox"
         command: go get github.com/mitchellh/gox

--- a/plugin/checkout_handlers.go
+++ b/plugin/checkout_handlers.go
@@ -53,10 +53,13 @@ type CheckOutHandler interface {
 	Delete(ctx context.Context, storage logical.Storage, serviceAccountName string) error
 }
 
+// InputValidator will be the first object called in the stack of handlers, to ensure items
+// expected in the signature are present, and to handle any other validation logic.
 type InputValidator struct {
 	CheckOutHandler
 }
 
+// CheckOut ensures all inputs in the signature are present.
 func (v *InputValidator) CheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error {
 	if err := v.validateInputs(ctx, storage, serviceAccountName, checkOut, true); err != nil {
 		return err
@@ -64,6 +67,7 @@ func (v *InputValidator) CheckOut(ctx context.Context, storage logical.Storage, 
 	return v.CheckOutHandler.CheckOut(ctx, storage, serviceAccountName, checkOut)
 }
 
+// CheckIn ensures all inputs in the signature are present.
 func (v *InputValidator) CheckIn(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
 	if err := v.validateInputs(ctx, storage, serviceAccountName, nil, false); err != nil {
 		return err
@@ -71,6 +75,7 @@ func (v *InputValidator) CheckIn(ctx context.Context, storage logical.Storage, s
 	return v.CheckOutHandler.CheckIn(ctx, storage, serviceAccountName)
 }
 
+// Status ensures all inputs in the signature are present.
 func (v *InputValidator) Status(ctx context.Context, storage logical.Storage, serviceAccountName string) (*CheckOut, error) {
 	if err := v.validateInputs(ctx, storage, serviceAccountName, nil, false); err != nil {
 		return nil, err
@@ -78,6 +83,7 @@ func (v *InputValidator) Status(ctx context.Context, storage logical.Storage, se
 	return v.CheckOutHandler.Status(ctx, storage, serviceAccountName)
 }
 
+// Delete ensures all inputs in the signature are present.
 func (v *InputValidator) Delete(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
 	if err := v.validateInputs(ctx, storage, serviceAccountName, nil, false); err != nil {
 		return err

--- a/plugin/checkout_handlers.go
+++ b/plugin/checkout_handlers.go
@@ -3,10 +3,10 @@ package plugin
 import (
 	"context"
 	"errors"
-	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"time"
 
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
+	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 

--- a/plugin/checkout_handlers_test.go
+++ b/plugin/checkout_handlers_test.go
@@ -120,8 +120,8 @@ func TestPasswordHandlerInterfaceFulfillment(t *testing.T) {
 	ctx, storage, serviceAccountName, checkOut := setup()
 
 	passwordHandler := &PasswordHandler{
-		client: &fakeSecretsClient{},
-		child:  &fakeCheckOutHandler{},
+		client:  &fakeSecretsClient{},
+		wrapped: &fakeCheckOutHandler{},
 	}
 
 	// There should be no error during check-out.
@@ -191,8 +191,8 @@ func TestServiceAccountLockerRace(t *testing.T) {
 	ctx, storage, serviceAccountName, checkOut := setup()
 
 	serviceAccountLocker := NewServiceAccountLocker(&PasswordHandler{
-		client: &fakeSecretsClient{},
-		child:  &StorageHandler{},
+		client:  &fakeSecretsClient{},
+		wrapped: &StorageHandler{},
 	})
 
 	rand.Seed(time.Now().UnixNano())

--- a/plugin/checkout_handlers_test.go
+++ b/plugin/checkout_handlers_test.go
@@ -121,8 +121,8 @@ func TestPasswordHandlerInterfaceFulfillment(t *testing.T) {
 	ctx, storage, serviceAccountName, checkOut := setup()
 
 	passwordHandler := &PasswordHandler{
-		client:  &fakeSecretsClient{},
-		wrapped: &fakeCheckOutHandler{},
+		client:          &fakeSecretsClient{},
+		CheckOutHandler: &fakeCheckOutHandler{},
 	}
 
 	// There should be no error during check-out.
@@ -192,8 +192,8 @@ func TestServiceAccountLockerRace(t *testing.T) {
 	ctx, storage, serviceAccountName, checkOut := setup()
 
 	serviceAccountLocker := NewServiceAccountLocker(&PasswordHandler{
-		client:  &fakeSecretsClient{},
-		wrapped: &StorageHandler{},
+		client:          &fakeSecretsClient{},
+		CheckOutHandler: &StorageHandler{},
 	})
 
 	rand.Seed(time.Now().UnixNano())

--- a/plugin/checkout_handlers_test.go
+++ b/plugin/checkout_handlers_test.go
@@ -95,23 +95,24 @@ func TestValidateInputs(t *testing.T) {
 	ctx, storage, serviceAccountName, checkOut := setup()
 
 	// Failure cases.
-	if err := validateInputs(nil, storage, serviceAccountName, checkOut, true); err == nil {
+	v := &InputValidator{}
+	if err := v.validateInputs(nil, storage, serviceAccountName, checkOut, true); err == nil {
 		t.Fatal("expected err because ctx isn't provided")
 	}
-	if err := validateInputs(ctx, nil, serviceAccountName, checkOut, true); err == nil {
+	if err := v.validateInputs(ctx, nil, serviceAccountName, checkOut, true); err == nil {
 		t.Fatal("expected err because storage isn't provided")
 	}
-	if err := validateInputs(ctx, storage, "", checkOut, true); err == nil {
+	if err := v.validateInputs(ctx, storage, "", checkOut, true); err == nil {
 		t.Fatal("expected err because serviceAccountName isn't provided")
 	}
-	if err := validateInputs(ctx, storage, serviceAccountName, nil, true); err == nil {
+	if err := v.validateInputs(ctx, storage, serviceAccountName, nil, true); err == nil {
 		t.Fatal("expected err because checkOut isn't provided")
 	}
 	// Success cases.
-	if err := validateInputs(ctx, storage, serviceAccountName, checkOut, true); err != nil {
+	if err := v.validateInputs(ctx, storage, serviceAccountName, checkOut, true); err != nil {
 		t.Fatal(err)
 	}
-	if err := validateInputs(ctx, storage, serviceAccountName, nil, false); err != nil {
+	if err := v.validateInputs(ctx, storage, serviceAccountName, nil, false); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
The `ServiceAccountLocker` will wrap the `PasswordHandler` and the `StorageHandler`. It's intended to prevent races. This is because, not only could the user be making updates to checkouts, but the `OverdueWatcher` could be checking things in when lending periods run out. We also could have some resource contention around service accounts.

This PR adds the locker, essentially making check-in, check-out, status check, and delete operations thread-safe. It also adds a test that attempts to create a race. When this test is run with the `-race` flag, no race is detected.

It also adds an `InputValidator` that will validate input at the beginning of the chain.