### PR TITLE
Add Overdue Watcher

### DIFF
--- a/plugin/checkout_handlers.go
+++ b/plugin/checkout_handlers.go
@@ -3,19 +3,26 @@ package plugin
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-const checkoutStoragePrefix = "library/"
+const checkoutStoragePrefix = "checkout/"
 
 var (
 	// ErrCurrentlyCheckedOut is returned when a check-out request is received
 	// for a service account that's already checked out.
 	ErrCurrentlyCheckedOut = errors.New("currently checked out")
+
+	// ErrNotCurrentlyCheckedOut is returned when a renewal request is received
+	// for a service account that's not checked out.
+	ErrNotCurrentlyCheckedOut = errors.New("not currently checked out")
 
 	// ErrNotFound is used when a requested item doesn't exist.
 	ErrNotFound = errors.New("not found")
@@ -30,6 +37,83 @@ type CheckOut struct {
 	Due                 time.Time     `json:"due"`
 }
 
+// NewCheckOutHandler instantiates a stack of checkout handlers appropriate for this type of instance.
+func NewCheckOutHandler(ctx context.Context, forLeader bool, logger hclog.Logger, storage logical.Storage, client secretsClient) (CheckOutHandler, error) {
+	// Generally speaking, calls will flow from the
+	// InputValidator -> OverdueWatcher -> ServiceAccountLocker -> PasswordHandler -> StorageHandler
+	// but some of these objects are only needed on the leader.
+	// Leader instances handle reads and writes, so all calls available
+	// on the CheckOutHandlers will be directly called.
+	// Follower instances handle reads only, so only the "Status" call
+	// will be directly called. Underlying storage will be updated via
+	// WAL replication.
+
+	var handlerStack CheckOutHandler
+
+	// The StorageHandler is needed on all types of instances to serve
+	// reads and writes.
+	handlerStack = &StorageHandler{}
+
+	// The PasswordHandler isn't needed on followers, since they will only
+	// call "Status", and the PasswordHandler is essentially a no-op on those.
+	if forLeader {
+		handlerStack = &PasswordHandler{
+			client:          client,
+			CheckOutHandler: handlerStack,
+		}
+	}
+
+	// The ServiceAccountLocker has RWMutexes that will keep the plugin
+	// thread-safe regardless of which type of server it is.
+	handlerStack = NewServiceAccountLocker(handlerStack)
+
+	if !forLeader {
+		// We're all set up for Status calls on followers now.
+		return &InputValidator{handlerStack}, nil
+	}
+
+	// The OverdueWatcher should only run on the leader because we only
+	// want it initiating check-ins in one place.
+	overdueWatcher := NewOverdueWatcher(logger, storage, handlerStack)
+	handlerStack = overdueWatcher
+
+	// On leaders, we now need to go through all the checkOuts. For ones
+	// whose lending period has expired, we need to check them in. We
+	// need to start watching the rest.
+	reserveNames, err := storage.List(ctx, reserveStoragePrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, reserveName := range reserveNames {
+		entry, err := storage.Get(ctx, reserveStoragePrefix+reserveName)
+		if err != nil {
+			return nil, err
+		}
+		reserve := &libraryReserve{}
+		if err := entry.DecodeJSON(reserve); err != nil {
+			return nil, err
+		}
+		for _, serviceAccountName := range reserve.ServiceAccountNames {
+			checkOut, err := handlerStack.Status(ctx, storage, serviceAccountName)
+			if err != nil {
+				return nil, err
+			}
+			if checkOut == nil {
+				continue
+			}
+			if !checkOut.Due.After(time.Now()) {
+				if err := handlerStack.CheckIn(ctx, storage, serviceAccountName); err != nil {
+					return nil, err
+				}
+			} else {
+				overdueWatcher.startWatching(serviceAccountName, checkOut.Due)
+			}
+		}
+	}
+	return &InputValidator{handlerStack}, nil
+}
+
 // CheckOutHandler is an interface used to break down tasks involved in managing checkouts. These tasks
 // are many and can be complex, so it helps to break them down into small, easily testable units
 // that help us build our confidence in the code.
@@ -37,6 +121,10 @@ type CheckOutHandler interface {
 	// CheckOut attempts to check out a service account. If the account is unavailable, it returns
 	// ErrCurrentlyCheckedOut.
 	CheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error
+
+	// RenewCheckOut will renew a present checkOut. If the account is not currently checked out, it returns
+	// ErrNotCurrentlyCheckedOut.
+	RenewCheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error
 
 	// CheckIn attempts to check in a service account. If an error occurs, the account remains checked out
 	// and can either be retried by the caller, or eventually may be checked in if it has a lending period
@@ -108,6 +196,146 @@ func (v *InputValidator) validateInputs(ctx context.Context, storage logical.Sto
 	return nil
 }
 
+func NewOverdueWatcher(logger hclog.Logger, origStorage logical.Storage, child CheckOutHandler) *OverdueWatcher {
+	return &OverdueWatcher{
+		storageMutex:  &sync.RWMutex{},
+		latestStorage: origStorage,
+		logger:        logger,
+		mapMutex:      &sync.RWMutex{},
+		renewalChans:  make(map[string]chan time.Time),
+		child:         child,
+	}
+}
+
+type OverdueWatcher struct {
+	// We always hold onto the last storage we've seen, and a mutex for it, so that the background process that's
+	// checking in overdue service accounts will use the latest storage configured.
+	storageMutex  *sync.RWMutex
+	latestStorage logical.Storage
+
+	logger       hclog.Logger
+	mapMutex     *sync.RWMutex
+	renewalChans map[string]chan time.Time
+	child        CheckOutHandler
+}
+
+func (w *OverdueWatcher) CheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error {
+	w.updateStorage(storage)
+	if err := w.child.CheckOut(ctx, storage, serviceAccountName, checkOut); err != nil {
+		return err
+	}
+	go w.startWatching(serviceAccountName, checkOut.Due)
+	return nil
+}
+
+func (w *OverdueWatcher) RenewCheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error {
+	w.updateStorage(storage)
+	if err := w.child.RenewCheckOut(ctx, storage, serviceAccountName, checkOut); err != nil {
+		return err
+	}
+	w.mapMutex.RLock()
+	renewalChan, ok := w.renewalChans[serviceAccountName]
+	w.mapMutex.RUnlock()
+	if !ok {
+		// We should never get here because if an account isn't currently checked out,
+		// we will have errored earlier. Just in case, let's error.
+		return errors.New("missing renewal channel")
+	}
+	renewalChan <- checkOut.Due
+	return nil
+}
+
+func (w *OverdueWatcher) CheckIn(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	w.updateStorage(storage)
+	if err := w.child.CheckIn(ctx, storage, serviceAccountName); err != nil {
+		return err
+	}
+	w.stopWatching(serviceAccountName)
+	return nil
+}
+
+func (w *OverdueWatcher) Status(ctx context.Context, storage logical.Storage, serviceAccountName string) (*CheckOut, error) {
+	w.updateStorage(storage)
+	return w.child.Status(ctx, storage, serviceAccountName)
+}
+
+func (w *OverdueWatcher) Delete(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	w.updateStorage(storage)
+	if err := w.child.Delete(ctx, storage, serviceAccountName); err != nil {
+		return err
+	}
+	w.stopWatching(serviceAccountName)
+	return nil
+}
+
+// updateStorage just stores the last storage we've seen in memory so it can be used by the overdue watcher to check
+// things back in.
+func (w *OverdueWatcher) updateStorage(storage logical.Storage) {
+	// If storage hasn't changed, we only need a read lock, which is way easier to get.
+	w.storageMutex.RLock()
+	if reflect.DeepEqual(storage, w.latestStorage) {
+		w.storageMutex.RUnlock()
+		return
+	}
+	// If it has changed, we'll need a write lock.
+	w.storageMutex.Lock()
+	w.latestStorage = storage
+	w.storageMutex.Unlock()
+}
+
+// startWatching is intended to be fired off as a goroutine. It will live in the background
+// until either:
+//  - The lending period ends and it successfully checks the account back in, OR
+//  - It receives a signal from the enclosing environment that it doesn't need to watch this account anymore.
+// It is exported so can be called directly on startup for accounts that are already checked out.
+func (w *OverdueWatcher) startWatching(serviceAccountName string, due time.Time) {
+	renewalChan := make(chan time.Time, 1)
+	w.mapMutex.Lock()
+	w.renewalChans[serviceAccountName] = renewalChan
+	w.mapMutex.Unlock()
+	lendingPeriodTimer := time.NewTimer(due.Sub(time.Now()))
+	for {
+		select {
+		case updatedDue, ok := <-renewalChan:
+			if !ok {
+				// The renewal channel was closed, signifying that we no longer need to watch
+				// this service account.
+				w.logger.Debug(fmt.Sprintf("%s was checked in", serviceAccountName))
+				return
+			}
+			// A new due date was sent, update how long we're waiting.
+			lendingPeriodTimer = time.NewTimer(updatedDue.Sub(time.Now()))
+			continue
+		case <-lendingPeriodTimer.C:
+			w.logger.Debug(fmt.Sprintf("%s was due at %s, attempting to check it in", serviceAccountName, due))
+			w.storageMutex.RLock()
+			err := w.child.CheckIn(context.Background(), w.latestStorage, serviceAccountName)
+			w.storageMutex.RUnlock()
+			if err != nil {
+				w.logger.Warn(fmt.Sprintf("couldn't check %s back in due to %s, will try again in a minute", serviceAccountName, err))
+				lendingPeriodTimer = time.NewTimer(time.Minute)
+				continue
+			}
+			w.logger.Debug(fmt.Sprintf("successfully checked %s in", serviceAccountName))
+			w.stopWatching(serviceAccountName)
+			return
+		}
+	}
+}
+
+func (w *OverdueWatcher) stopWatching(serviceAccountName string) {
+	w.mapMutex.RLock()
+	renewalChan, ok := w.renewalChans[serviceAccountName]
+	w.mapMutex.RUnlock()
+	if !ok {
+		return
+	}
+	close(renewalChan)
+	w.mapMutex.Lock()
+	delete(w.renewalChans, serviceAccountName)
+	w.mapMutex.Unlock()
+}
+
 // NewServiceAccountLocker is the preferable way to instantiate a ServiceAccountLocker
 // because it populates the map of locks for you.
 func NewServiceAccountLocker(wrapped CheckOutHandler) *ServiceAccountLocker {
@@ -121,6 +349,7 @@ func NewServiceAccountLocker(wrapped CheckOutHandler) *ServiceAccountLocker {
 type ServiceAccountLocker struct {
 	// This is, in effect, being used as a map[string]*sync.RWMutex
 	locks *sync.Map
+
 	CheckOutHandler
 }
 
@@ -130,6 +359,13 @@ func (l *ServiceAccountLocker) CheckOut(ctx context.Context, storage logical.Sto
 	lock.Lock()
 	defer lock.Unlock()
 	return l.CheckOutHandler.CheckOut(ctx, storage, serviceAccountName, checkOut)
+}
+
+func (l *ServiceAccountLocker) RenewCheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error {
+	lock := l.getOrCreateLock(serviceAccountName)
+	lock.Lock()
+	defer lock.Unlock()
+	return l.CheckOutHandler.RenewCheckOut(ctx, storage, serviceAccountName, checkOut)
 }
 
 // CheckIn holds a write lock for the duration of the work to be done.
@@ -175,6 +411,11 @@ type PasswordHandler struct {
 // CheckOut requires no further action from the password handler other than passing along the request.
 func (h *PasswordHandler) CheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error {
 	return h.CheckOutHandler.CheckOut(ctx, storage, serviceAccountName, checkOut)
+}
+
+// RenewCheckOut requires no further action from the password handler other than passing along the request.
+func (h *PasswordHandler) RenewCheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error {
+	return h.CheckOutHandler.RenewCheckOut(ctx, storage, serviceAccountName, checkOut)
 }
 
 // CheckIn rotates the service account's password remotely and stores it locally.
@@ -257,6 +498,25 @@ func (h *StorageHandler) CheckOut(ctx context.Context, storage logical.Storage, 
 		return ErrCurrentlyCheckedOut
 	}
 	// Since it's not, store the new check-out.
+	entry, err := logical.StorageEntryJSON(checkoutStoragePrefix+serviceAccountName, checkOut)
+	if err != nil {
+		return err
+	}
+	return storage.Put(ctx, entry)
+}
+
+// RenewCheckOut will return:
+//  - Nil if it was successfully able to perform the requested renewal.
+//  - ErrNotCurrentlyCheckedOut if the account wasn't already checked out.
+//  - Some other err if it was unable to complete successfully.
+func (h *StorageHandler) RenewCheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error {
+	// Check if the service account is currently checked out.
+	if entry, err := storage.Get(ctx, checkoutStoragePrefix+serviceAccountName); err != nil {
+		return err
+	} else if entry == nil {
+		return ErrNotCurrentlyCheckedOut
+	}
+	// Store the new check-out.
 	entry, err := logical.StorageEntryJSON(checkoutStoragePrefix+serviceAccountName, checkOut)
 	if err != nil {
 		return err

--- a/plugin/path_reserves.go
+++ b/plugin/path_reserves.go
@@ -1,0 +1,14 @@
+package plugin
+
+import "time"
+
+const reserveStoragePrefix = "reserve/"
+
+type libraryReserve struct {
+	ServiceAccountNames []string      `json:"service_account_names"`
+	LendingPeriod       time.Duration `json:"lending_period"`
+}
+
+// TODO this is where the following endpoint groups will live:
+//  - /<mount>/library
+//  - /<mount>/library/:name


### PR DESCRIPTION
This PR adds an `OverdueWatcher` to the group of `CheckOutHandlers`.

Since the `OverdueWatcher` must check-in or watch check-outs when it's starting up on a leader, it's time to add the code that stitches all the handlers together based on the kind of instance they're on.

The race detection test is boosted to check for races throughout the whole stack, on each type of instance. A stub file is placed for where an endpoint will be created (in a separate PR). 

A `RenewCheckOut` method is added because we decided to manage checkouts with leases in some situations. Leases can be renewed and revoked. This necessitated the addition.