### PR TITLE
Add reserve API endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-errors/errors v1.0.1
 	github.com/go-ldap/ldap v3.0.2+incompatible
 	github.com/hashicorp/go-hclog v0.8.0
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/hashicorp/vault/api v1.0.5-0.20190814205728-e9c5cd8aca98
 	github.com/hashicorp/vault/sdk v0.1.14-0.20190814205504-1cad00d1133b

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -22,11 +22,14 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 
 func newBackend(client secretsClient) *backend {
 	adBackend := &backend{
-		client:          client,
-		roleCache:       cache.New(roleCacheExpiration, roleCacheCleanup),
-		credCache:       cache.New(credCacheExpiration, credCacheCleanup),
-		rotateRootLock:  new(int32),
-		checkOutHandler: &NoOpHandler{}, // TODO replace with real handler in later PR, may be a different object
+		client:         client,
+		roleCache:      cache.New(roleCacheExpiration, roleCacheCleanup),
+		credCache:      cache.New(credCacheExpiration, credCacheCleanup),
+		rotateRootLock: new(int32),
+		checkOutHandler: &PasswordHandler{ // TODO the object model may change here but we do need to place something realistic here for testing
+			client: client,
+			child:  &StorageHandler{},
+		},
 	}
 	adBackend.Backend = &framework.Backend{
 		Help: backendHelp,

--- a/plugin/backend_checkouts_test.go
+++ b/plugin/backend_checkouts_test.go
@@ -128,7 +128,11 @@ func ListReserves(t *testing.T) {
 	if resp == nil {
 		t.Fatal("expected a response")
 	}
-	if "test-reserve" != resp.Data["keys"].([]string)[0] {
+	listedKeys := resp.Data["keys"].([]string)
+	if len(listedKeys) != 1 {
+		t.Fatalf("expected 1 key but received %s", listedKeys)
+	}
+	if "test-reserve" != listedKeys[0] {
 		t.Fatal("expected test-reserve to be the only listed item")
 	}
 }

--- a/plugin/backend_checkouts_test.go
+++ b/plugin/backend_checkouts_test.go
@@ -41,7 +41,7 @@ func WriteReserve(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp != nil {
-		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+		t.Fatalf("expected an empty response, got: %v", resp)
 	}
 }
 

--- a/plugin/backend_checkouts_test.go
+++ b/plugin/backend_checkouts_test.go
@@ -59,7 +59,7 @@ func AddAnotherServiceAccount(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp != nil {
-		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+		t.Fatalf("expected an empty response, got: %v", resp)
 	}
 }
 
@@ -77,7 +77,7 @@ func RemoveServiceAccount(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp != nil {
-		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+		t.Fatalf("expected an empty response, got: %v", resp)
 	}
 }
 
@@ -144,6 +144,6 @@ func DeleteReserve(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp != nil {
-		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+		t.Fatalf("expected an empty response, got: %v", resp)
 	}
 }

--- a/plugin/backend_checkouts_test.go
+++ b/plugin/backend_checkouts_test.go
@@ -32,7 +32,7 @@ func WriteReserve(t *testing.T) {
 		Path:      libraryPrefix + "test-reserve",
 		Storage:   testStorage,
 		Data: map[string]interface{}{
-			"service_account_names": []string{"tester1@example.com", "tester2@example.com"},
+			"service_account_names": []string{"tester1@example.com", "tester20@example.com"},
 			"lending_period":        "10h",
 		},
 	}
@@ -51,7 +51,7 @@ func AddAnotherServiceAccount(t *testing.T) {
 		Path:      libraryPrefix + "test-reserve",
 		Storage:   testStorage,
 		Data: map[string]interface{}{
-			"service_account_names": []string{"tester1@example.com", "tester2@example.com", "tester3@example.com"},
+			"service_account_names": []string{"tester1@example.com", "tester21@example.com", "tester3@example.com"},
 		},
 	}
 	resp, err := testBackend.HandleRequest(ctx, req)
@@ -69,7 +69,7 @@ func RemoveServiceAccount(t *testing.T) {
 		Path:      libraryPrefix + "test-reserve",
 		Storage:   testStorage,
 		Data: map[string]interface{}{
-			"service_account_names": []string{"tester1@example.com", "tester2@example.com"},
+			"service_account_names": []string{"tester1@example.com", "tester22@example.com"},
 		},
 	}
 	resp, err := testBackend.HandleRequest(ctx, req)
@@ -109,8 +109,11 @@ func WriteReserveWithConflictingServiceAccounts(t *testing.T) {
 			"service_account_names": "tester1@example.com",
 		},
 	}
-	_, err := testBackend.HandleRequest(ctx, req)
-	if err == nil {
+	resp, err := testBackend.HandleRequest(ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || !resp.IsError() {
 		t.Fatal("expected err response because we're adding a service account managed by another reserve")
 	}
 }

--- a/plugin/backend_checkouts_test.go
+++ b/plugin/backend_checkouts_test.go
@@ -1,0 +1,149 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// The AD library of service accounts that can be checked out
+// is a discrete set of features. This test suite provides
+// end-to-end tests of these interrelated endpoints.
+func TestCheckOuts(t *testing.T) {
+	// Plant a config.
+	t.Run("plant config", PlantConfig)
+
+	// Exercise all reserve endpoints.
+	t.Run("write reserve", WriteReserve)
+	t.Run("read reserve", ReadReserve)
+	t.Run("write conflicting reserve", WriteReserveWithConflictingServiceAccounts)
+	t.Run("list reserves", ListReserves)
+	t.Run("delete reserve", DeleteReserve)
+
+	// Do some common updates on reserves and ensure they work.
+	t.Run("write reserve", WriteReserve)
+	t.Run("add service account", AddAnotherServiceAccount)
+	t.Run("remove service account", RemoveServiceAccount)
+}
+
+func WriteReserve(t *testing.T) {
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      libraryPrefix + "test-reserve",
+		Storage:   testStorage,
+		Data: map[string]interface{}{
+			"service_account_names": []string{"tester1@example.com", "tester2@example.com"},
+			"lending_period":        "10h",
+		},
+	}
+	resp, err := testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp != nil {
+		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+	}
+}
+
+func AddAnotherServiceAccount(t *testing.T) {
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      libraryPrefix + "test-reserve",
+		Storage:   testStorage,
+		Data: map[string]interface{}{
+			"service_account_names": []string{"tester1@example.com", "tester2@example.com", "tester3@example.com"},
+		},
+	}
+	resp, err := testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp != nil {
+		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+	}
+}
+
+func RemoveServiceAccount(t *testing.T) {
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      libraryPrefix + "test-reserve",
+		Storage:   testStorage,
+		Data: map[string]interface{}{
+			"service_account_names": []string{"tester1@example.com", "tester2@example.com"},
+		},
+	}
+	resp, err := testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp != nil {
+		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+	}
+}
+
+func ReadReserve(t *testing.T) {
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      libraryPrefix + "test-reserve",
+		Storage:   testStorage,
+	}
+	resp, err := testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("expected a response")
+	}
+	serviceAccountNames := resp.Data["service_account_names"].([]string)
+	if len(serviceAccountNames) != 2 {
+		t.Fatal("expected 2")
+	}
+}
+
+func WriteReserveWithConflictingServiceAccounts(t *testing.T) {
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      libraryPrefix + "test-reserve2",
+		Storage:   testStorage,
+		Data: map[string]interface{}{
+			"service_account_names": "tester1@example.com",
+		},
+	}
+	_, err := testBackend.HandleRequest(ctx, req)
+	if err == nil {
+		t.Fatal("expected err response because we're adding a service account managed by another reserve")
+	}
+}
+
+func ListReserves(t *testing.T) {
+	req := &logical.Request{
+		Operation: logical.ListOperation,
+		Path:      libraryPrefix,
+		Storage:   testStorage,
+	}
+	resp, err := testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("expected a response")
+	}
+	if "test-reserve" != resp.Data["keys"].([]string)[0] {
+		t.Fatal("expected test-reserve to be the only listed item")
+	}
+}
+
+func DeleteReserve(t *testing.T) {
+	req := &logical.Request{
+		Operation: logical.DeleteOperation,
+		Path:      libraryPrefix + "test-reserve",
+		Storage:   testStorage,
+	}
+	resp, err := testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp != nil {
+		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+	}
+}

--- a/plugin/checkout_handlers.go
+++ b/plugin/checkout_handlers.go
@@ -52,6 +52,32 @@ type CheckOutHandler interface {
 	Delete(ctx context.Context, storage logical.Storage, serviceAccountName string) error
 }
 
+// TODO this will be deleted before launch, it's just a placeholder.
+// NoOpHandler is a handler that fulfills the CheckOutHandler interface during
+// development. It will be replaced with real handlers later, and deleted before
+// this feature is merged.
+// The handlers in this package are intended to also be moved into their own package
+// which will only export minimal objects, and some are intended to be combined.
+// This will be in its own discrete PR after API endpoints have been written, which
+// will fully illuminate what "hooks" are (and aren't) really needed for performing work.
+type NoOpHandler struct{}
+
+func (n *NoOpHandler) CheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error {
+	return nil
+}
+
+func (n *NoOpHandler) CheckIn(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	return nil
+}
+
+func (n *NoOpHandler) Status(ctx context.Context, storage logical.Storage, serviceAccountName string) (*CheckOut, error) {
+	return nil, nil
+}
+
+func (n *NoOpHandler) Delete(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	return nil
+}
+
 // PasswordHandler is responsible for rolling and storing a service account's password upon check-in.
 type PasswordHandler struct {
 	client secretsClient

--- a/plugin/checkout_handlers_test.go
+++ b/plugin/checkout_handlers_test.go
@@ -40,6 +40,11 @@ func Test_StorageHandler(t *testing.T) {
 
 	storageHandler := &StorageHandler{}
 
+	// Service accounts must initially be checked in to the library
+	if err := storageHandler.CheckIn(ctx, storage, serviceAccountName); err != nil {
+		t.Fatal(err)
+	}
+
 	// If we try to check something out for the first time, it should succeed.
 	if err := storageHandler.CheckOut(ctx, storage, serviceAccountName, testCheckOut); err != nil {
 		t.Fatal(err)
@@ -54,7 +59,7 @@ func Test_StorageHandler(t *testing.T) {
 		t.Fatal("storedCheckOut should not be nil")
 	}
 	if !reflect.DeepEqual(testCheckOut, storedCheckOut) {
-		t.Fatalf(fmt.Sprintf(`expected %s to be equal to %s`, testCheckOut, storedCheckOut))
+		t.Fatalf(fmt.Sprintf(`expected %+v to be equal to %+v`, testCheckOut, storedCheckOut))
 	}
 
 	// If we try to check something out that's already checked out, we should
@@ -75,7 +80,7 @@ func Test_StorageHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if storedCheckOut != nil {
+	if !storedCheckOut.IsAvailable {
 		t.Fatal("storedCheckOut should be nil")
 	}
 

--- a/plugin/path_reserves.go
+++ b/plugin/path_reserves.go
@@ -1,0 +1,312 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/strutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const libraryPrefix = "library/"
+
+type libraryReserve struct {
+	ServiceAccountNames []string      `json:"service_account_names"`
+	LendingPeriod       time.Duration `json:"lending_period"`
+}
+
+func (b *backend) pathListReserves() *framework.Path {
+	return &framework.Path{
+		Pattern: libraryPrefix + "?$",
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback: b.reserveListOperation,
+			},
+		},
+		HelpSynopsis:    pathListReservesHelpSyn,
+		HelpDescription: pathListReservesHelpDesc,
+	}
+}
+
+func (b *backend) reserveListOperation(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	keys, err := req.Storage.List(ctx, libraryPrefix)
+	if err != nil {
+		return nil, err
+	}
+	return logical.ListResponse(keys), nil
+}
+
+func (b *backend) pathReserves() *framework.Path {
+	return &framework.Path{
+		Pattern: libraryPrefix + framework.GenericNameRegex("name"),
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeLowerCaseString,
+				Description: "Name of the reserve",
+				Required:    true,
+			},
+			"service_account_names": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: "The username/logon name for the service accounts with which this reserve will be associated.",
+			},
+			"lending_period": {
+				Type:        framework.TypeDurationSecond,
+				Description: "In seconds, the default length of time before check-outs will expire.",
+				Default:     24 * 60 * 60, // 24 hours
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.operationReserveCreate,
+				Summary:  "Create a library reserve.",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.operationReserveUpdate,
+				Summary:  "Update a library reserve.",
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.operationReserveRead,
+				Summary:  "Read a library reserve.",
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.operationReserveDelete,
+				Summary:  "Delete a library reserve.",
+			},
+		},
+		ExistenceCheck:  b.operationReserveExistenceCheck,
+		HelpSynopsis:    reserveHelpSynopsis,
+		HelpDescription: reserveHelpDescription,
+	}
+}
+
+func (b *backend) operationReserveExistenceCheck(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (bool, error) {
+	reserve, err := readReserve(ctx, req.Storage, fieldData.Get("name").(string))
+	if err != nil {
+		return false, err
+	}
+	return reserve != nil, nil
+}
+
+func (b *backend) operationReserveCreate(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+	reserveName := fieldData.Get("name").(string)
+	serviceAccountNames := fieldData.Get("service_account_names").([]string)
+	lendingPeriodRaw, lendingPeriodSent := fieldData.GetOk("lending_period")
+	if !lendingPeriodSent {
+		lendingPeriodRaw = fieldData.Schema["lending_period"].Default
+	}
+	lendingPeriod := time.Duration(lendingPeriodRaw.(int)) * time.Second
+
+	if len(serviceAccountNames) == 0 {
+		return logical.ErrorResponse(`"service_account_names" must be provided`), nil
+	}
+	if err := ensureNotInAnotherReserve(ctx, req.Storage, serviceAccountNames); err != nil {
+		return nil, err
+	}
+	reserve := &libraryReserve{
+		ServiceAccountNames: serviceAccountNames,
+		LendingPeriod:       lendingPeriod,
+	}
+	if err := storeReserve(ctx, req.Storage, reserveName, reserve); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (b *backend) operationReserveUpdate(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+	reserveName := fieldData.Get("name").(string)
+
+	newServiceAccountNamesRaw, newServiceAccountNamesSent := fieldData.GetOk("service_account_names")
+	var newServiceAccountNames []string
+	if newServiceAccountNamesSent {
+		newServiceAccountNames = newServiceAccountNamesRaw.([]string)
+	}
+
+	lendingPeriodRaw, lendingPeriodSent := fieldData.GetOk("lending_period")
+	if !lendingPeriodSent {
+		lendingPeriodRaw = fieldData.Schema["lending_period"].Default
+	}
+	lendingPeriod := time.Duration(lendingPeriodRaw.(int)) * time.Second
+
+	reserve, err := readReserve(ctx, req.Storage, reserveName)
+	if err != nil {
+		return nil, err
+	}
+	if reserve == nil {
+		return logical.ErrorResponse(`"%s" doesn't exist`, reserveName), nil
+	}
+	if newServiceAccountNamesSent {
+		// For new service accounts, we need to make sure they're not already handled by another reserve.
+		var beingAdded []string
+		for _, newServiceAccountName := range newServiceAccountNames {
+			if strutil.StrListContains(reserve.ServiceAccountNames, newServiceAccountName) {
+				// It's not new.
+				continue
+			}
+			beingAdded = append(beingAdded, newServiceAccountName)
+		}
+		if len(beingAdded) > 0 {
+			if err := ensureNotInAnotherReserve(ctx, req.Storage, beingAdded); err != nil {
+				return nil, err
+			}
+		}
+		// For service accounts we won't be handling anymore, we need to remove their passwords
+		// from storage.
+		var deletionErrs error
+		for _, prevServiceAccountName := range reserve.ServiceAccountNames {
+			if strutil.StrListContains(newServiceAccountNames, prevServiceAccountName) {
+				// This previous account isn't being deleted.
+				continue
+			}
+			if err := b.deleteReserveServiceAccount(ctx, req.Storage, prevServiceAccountName); err != nil {
+				deletionErrs = multierror.Append(deletionErrs, err)
+			}
+		}
+		if deletionErrs != nil {
+			return nil, deletionErrs
+		}
+		reserve.ServiceAccountNames = newServiceAccountNames
+	}
+	if lendingPeriodSent {
+		reserve.LendingPeriod = lendingPeriod
+	}
+	if err := storeReserve(ctx, req.Storage, reserveName, reserve); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (b *backend) operationReserveRead(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+	reserveName := fieldData.Get("name").(string)
+	reserve, err := readReserve(ctx, req.Storage, reserveName)
+	if err != nil {
+		return nil, err
+	}
+	if reserve == nil {
+		return nil, nil
+	}
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"service_account_names": reserve.ServiceAccountNames,
+			"lending_period":        int64(reserve.LendingPeriod.Seconds()),
+		},
+	}, nil
+}
+
+func (b *backend) operationReserveDelete(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+	reserveName := fieldData.Get("name").(string)
+	reserve, err := readReserve(ctx, req.Storage, reserveName)
+	if err != nil {
+		return nil, err
+	}
+	if reserve == nil {
+		return nil, nil
+	}
+	// We need to remove all the passwords we'd stored for these service accounts.
+	var deletionErrs error
+	for _, serviceAccountName := range reserve.ServiceAccountNames {
+		if err := b.deleteReserveServiceAccount(ctx, req.Storage, serviceAccountName); err != nil {
+			deletionErrs = multierror.Append(deletionErrs, err)
+		}
+	}
+	if deletionErrs != nil {
+		return nil, deletionErrs
+	}
+	if err := req.Storage.Delete(ctx, libraryPrefix+reserveName); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// readReserve is a helper method for reading a reserve from storage by name.
+// It's intended to be used anywhere in the plugin. It may return nil, nil if
+// a libraryReserve doesn't currently exist for a given reserveName.
+func readReserve(ctx context.Context, storage logical.Storage, reserveName string) (*libraryReserve, error) {
+	entry, err := storage.Get(ctx, libraryPrefix+reserveName)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+	reserve := &libraryReserve{}
+	if err := entry.DecodeJSON(reserve); err != nil {
+		return nil, err
+	}
+	return reserve, nil
+}
+
+// storeReserve is only intended to be used inside path_reserves.go, because this is the only place
+// that is intended to be editing reserves.
+func storeReserve(ctx context.Context, storage logical.Storage, reserveName string, reserve *libraryReserve) error {
+	entry, err := logical.StorageEntryJSON(libraryPrefix+reserveName, reserve)
+	if err != nil {
+		return err
+	}
+	return storage.Put(ctx, entry)
+}
+
+// ensureNotInAnotherReserve is a helper method for checking that new service accounts aren't already being
+// managed by another reserve. This is because we would experience a lot of unexpected behavior if the same
+// service account were being checked in (with its password rolled) at different times through another
+// reserve, and it could be difficult to debug because it'd be happening outside the times we'd be looking
+// at in the logs.
+func ensureNotInAnotherReserve(ctx context.Context, storage logical.Storage, newServiceAccountNames []string) error {
+	// Gather up all the service accounts currently being managed.
+	preExistingReserveNames, err := storage.List(ctx, libraryPrefix)
+	if err != nil {
+		return err
+	}
+	preExistingServiceAccountNames := make(map[string]bool)
+	for _, preExistingReserveName := range preExistingReserveNames {
+		preExistingReserve, err := readReserve(ctx, storage, preExistingReserveName)
+		if err != nil {
+			return err
+		}
+		for _, preExistingServiceAccountName := range preExistingReserve.ServiceAccountNames {
+			preExistingServiceAccountNames[preExistingServiceAccountName] = true
+		}
+	}
+
+	// Check through the new ones to make sure they're not already in another reserve.
+	var preExistenceErrs error
+	for _, newServiceAccountName := range newServiceAccountNames {
+		if _, exists := preExistingServiceAccountNames[newServiceAccountName]; exists {
+			preExistenceErrs = multierror.Append(preExistenceErrs, fmt.Errorf(`can't append %s because it's already managed by another reserve`, newServiceAccountName))
+		}
+	}
+	return preExistenceErrs
+}
+
+// deleteReserveServiceAccount errors if an account can't presently be deleted, or deletes it.
+func (b *backend) deleteReserveServiceAccount(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
+	if checkOut, err := b.checkOutHandler.Status(ctx, storage, serviceAccountName); err != nil {
+		return err
+	} else if checkOut != nil {
+		return fmt.Errorf(`"%s" can't be deleted because it is currently checked out'`, serviceAccountName)
+	}
+	if err := b.checkOutHandler.Delete(ctx, storage, serviceAccountName); err != nil {
+		return err
+	}
+	return nil
+}
+
+const (
+	reserveHelpSynopsis = `
+Manage reserves to build a library of service accounts that can be checked out.
+`
+	reserveHelpDescription = `
+This endpoint allows you to read, write, and delete individual reserves that are used for checking out service accounts.
+
+Deleting a reserve can only be performed if all of its service accounts are currently checked in.
+`
+	pathListReservesHelpSyn = `
+List the name of each reserve currently stored.
+`
+	pathListReservesHelpDesc = `
+To learn which service accounts are being managed by Vault, list the reserve names using
+this endpoint. Then read any individual reserve by name to learn more.
+`
+)

--- a/plugin/path_reserves.go
+++ b/plugin/path_reserves.go
@@ -271,8 +271,7 @@ func readReserve(ctx context.Context, storage logical.Storage, reserveName strin
 	return reserve, nil
 }
 
-// storeReserve is only intended to be used inside path_reserves.go, because this is the only place
-// that is intended to be editing reserves.
+// storeReserve stores a library reserve.
 func storeReserve(ctx context.Context, storage logical.Storage, reserveName string, reserve *libraryReserve) error {
 	entry, err := logical.StorageEntryJSON(libraryPrefix+reserveName, reserve)
 	if err != nil {

--- a/plugin/path_reserves.go
+++ b/plugin/path_reserves.go
@@ -93,11 +93,7 @@ func (b *backend) operationReserveExistenceCheck(ctx context.Context, req *logic
 func (b *backend) operationReserveCreate(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
 	reserveName := fieldData.Get("name").(string)
 	serviceAccountNames := fieldData.Get("service_account_names").([]string)
-	lendingPeriodRaw, lendingPeriodSent := fieldData.GetOk("lending_period")
-	if !lendingPeriodSent {
-		lendingPeriodRaw = fieldData.Schema["lending_period"].Default
-	}
-	lendingPeriod := time.Duration(lendingPeriodRaw.(int)) * time.Second
+	lendingPeriod := time.Duration(fieldData.Get("lending_period").(int)) * time.Second
 
 	if len(serviceAccountNames) == 0 {
 		return logical.ErrorResponse(`"service_account_names" must be provided`), nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -54,6 +54,7 @@ github.com/hashicorp/vault/api
 github.com/hashicorp/vault/sdk/plugin
 github.com/hashicorp/vault/sdk/framework
 github.com/hashicorp/vault/sdk/helper/ldaputil
+github.com/hashicorp/vault/sdk/helper/strutil
 github.com/hashicorp/vault/sdk/logical
 github.com/hashicorp/vault/sdk/helper/consts
 github.com/hashicorp/vault/sdk/helper/hclutil
@@ -66,7 +67,6 @@ github.com/hashicorp/vault/sdk/plugin/pb
 github.com/hashicorp/vault/sdk/helper/errutil
 github.com/hashicorp/vault/sdk/helper/logging
 github.com/hashicorp/vault/sdk/helper/salt
-github.com/hashicorp/vault/sdk/helper/strutil
 github.com/hashicorp/vault/sdk/version
 github.com/hashicorp/vault/sdk/helper/tlsutil
 github.com/hashicorp/vault/sdk/physical


### PR DESCRIPTION
This PR adds all endpoints related to managing a group of service accounts available for checkout, called a "reserve".

The endpoints added here are:
- `LIST /<mount>/library`
- `POST /<mount>/library/:name`
- `READ /<mount>/library/:name`
- `DELETE /<mount>/library/:name`

The next PRs I'm planning will be:
- One adding all endpoints related to check-ins and check-outs
- One adding an `OverdueWatcher` and finalizing the `CheckOutHandler` object model as per our team discussion