### PR TITLE
Add checkout status endpoint

### DIFF
--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -41,6 +41,7 @@ func newBackend(client secretsClient) *backend {
 			adBackend.pathRotateCredentials(),
 
 			// The following paths are for AD credential checkout.
+			adBackend.pathReserveStatus(),
 			adBackend.pathReserves(),
 			adBackend.pathListReserves(),
 		},

--- a/plugin/backend_checkouts_test.go
+++ b/plugin/backend_checkouts_test.go
@@ -16,6 +16,7 @@ func TestCheckOuts(t *testing.T) {
 	// Exercise all reserve endpoints.
 	t.Run("write reserve", WriteReserve)
 	t.Run("read reserve", ReadReserve)
+	t.Run("read reserve status", ReadReserveStatus)
 	t.Run("write conflicting reserve", WriteReserveWithConflictingServiceAccounts)
 	t.Run("list reserves", ListReserves)
 	t.Run("delete reserve", DeleteReserve)
@@ -97,6 +98,28 @@ func ReadReserve(t *testing.T) {
 	serviceAccountNames := resp.Data["service_account_names"].([]string)
 	if len(serviceAccountNames) != 2 {
 		t.Fatal("expected 2")
+	}
+}
+
+func ReadReserveStatus(t *testing.T) {
+	req := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      libraryPrefix + "test-reserve/status",
+		Storage:   testStorage,
+	}
+	resp, err := testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("expected a response")
+	}
+	if len(resp.Data) != 2 {
+		t.Fatal("length should be 2 because there are two service accounts in this reserve")
+	}
+	testerStatus := resp.Data["tester1@example.com"].(map[string]interface{})
+	if !testerStatus["available"].(bool) {
+		t.Fatal("should be available for checkout")
 	}
 }
 

--- a/plugin/path_checkouts.go
+++ b/plugin/path_checkouts.go
@@ -1,0 +1,72 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func (b *backend) pathReserveStatus() *framework.Path {
+	return &framework.Path{
+		Pattern: libraryPrefix + framework.GenericNameRegex("name") + "/status$",
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeLowerCaseString,
+				Description: "Name of the reserve",
+				Required:    true,
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.operationReserveStatus,
+				Summary:  "Check the status of the service accounts in a library reserve.",
+			},
+		},
+		HelpSynopsis: `Check the status of the service accounts in a library.`,
+	}
+}
+
+func (b *backend) operationReserveStatus(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+	reserveName := fieldData.Get("name").(string)
+	reserve, err := readReserve(ctx, req.Storage, reserveName)
+	if err != nil {
+		return nil, err
+	}
+	if reserve == nil {
+		return logical.ErrorResponse(`"%s" doesn't exist`, reserveName), nil
+	}
+	respData := make(map[string]interface{})
+	for _, serviceAccountName := range reserve.ServiceAccountNames {
+		checkOut, err := b.checkOutHandler.Status(ctx, req.Storage, serviceAccountName)
+		if err != nil {
+			return nil, err
+		}
+		if checkOut == nil {
+			// This should never happen because for every service account, it should have
+			// been checked in when it was first created.
+			b.Logger().Warn(fmt.Sprintf("%s should have been checked in, but wasn't, checking it in now", serviceAccountName))
+			if err := b.checkOutHandler.CheckIn(ctx, req.Storage, serviceAccountName); err != nil {
+				return nil, err
+			}
+		}
+
+		// It's checked out, so build a map giving all the things.
+		status := map[string]interface{}{
+			"available":      checkOut.IsAvailable,
+			"lending_period": int64(checkOut.LendingPeriod.Seconds()),
+			"due":            checkOut.Due.Format(time.RFC3339Nano),
+		}
+		if checkOut.BorrowerClientToken != "" {
+			status["borrower_client_token"] = checkOut.BorrowerClientToken
+		} else {
+			status["borrower_entity_id"] = checkOut.BorrowerEntityID
+		}
+		respData[serviceAccountName] = status
+	}
+	return &logical.Response{
+		Data: respData,
+	}, nil
+}

--- a/plugin/path_checkouts.go
+++ b/plugin/path_checkouts.go
@@ -3,9 +3,10 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
-	"time"
 )
 
 func (b *backend) pathReserveStatus() *framework.Path {


### PR DESCRIPTION
Adds the following endpoint:

`READ /<mount>/library/:name/status`

```
{
    "web-workers-1@example.com": {
        "available": true
    },
    "web-workers-2@example.com": {
        "available": false,
        "borrower_entity_id": "some ID",
        "lending_period": "4h",
        "due": "2018-05-24T17:14:38.677370855Z"
    }
}
```