### PR TITLE
Replace lending period with ttl and max ttl

### DIFF
--- a/plugin/backend_checkouts_test.go
+++ b/plugin/backend_checkouts_test.go
@@ -36,7 +36,8 @@ func WriteReserve(t *testing.T) {
 		Storage:   testStorage,
 		Data: map[string]interface{}{
 			"service_account_names":        []string{"tester1@example.com", "tester2@example.com"},
-			"lending_period":               "10h",
+			"ttl":                          "10h",
+			"max_ttl":                      "11h",
 			"disable_check_in_enforcement": true,
 		},
 	}
@@ -106,6 +107,14 @@ func ReadReserve(t *testing.T) {
 	if !disableCheckInEnforcement {
 		t.Fatal("check-in enforcement should be disabled")
 	}
+	ttl := resp.Data["ttl"].(int64)
+	if ttl != 10*60*60 { // 10 hours
+		t.Fatal(ttl)
+	}
+	maxTTL := resp.Data["max_ttl"].(int64)
+	if maxTTL != 11*60*60 { // 11 hours
+		t.Fatal(maxTTL)
+	}
 }
 
 func WriteReserveToggleOff(t *testing.T) {
@@ -115,7 +124,7 @@ func WriteReserveToggleOff(t *testing.T) {
 		Storage:   testStorage,
 		Data: map[string]interface{}{
 			"service_account_names":        []string{"tester1@example.com", "tester2@example.com"},
-			"lending_period":               "10h",
+			"ttl":                          "10h",
 			"disable_check_in_enforcement": false,
 		},
 	}

--- a/plugin/checkout_handlers.go
+++ b/plugin/checkout_handlers.go
@@ -23,11 +23,10 @@ var (
 // CheckOut provides information for a service account that is currently
 // checked out.
 type CheckOut struct {
-	IsAvailable         bool          `json:"is_available"`
-	BorrowerEntityID    string        `json:"borrower_entity_id"`
-	BorrowerClientToken string        `json:"borrower_client_token"`
-	LendingPeriod       time.Duration `json:"lending_period"`
-	Due                 time.Time     `json:"due"`
+	IsAvailable         bool      `json:"is_available"`
+	BorrowerEntityID    string    `json:"borrower_entity_id"`
+	BorrowerClientToken string    `json:"borrower_client_token"`
+	Due                 time.Time `json:"due"`
 }
 
 // CheckOutHandler is an interface used to break down tasks involved in managing checkouts. These tasks
@@ -40,7 +39,7 @@ type CheckOutHandler interface {
 	CheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error
 
 	// CheckIn attempts to check in a service account. If an error occurs, the account remains checked out
-	// and can either be retried by the caller, or eventually may be checked in if it has a lending period
+	// and can either be retried by the caller, or eventually may be checked in if it has a ttl
 	// that ends.
 	CheckIn(ctx context.Context, storage logical.Storage, serviceAccountName string) error
 
@@ -69,7 +68,7 @@ func (h *PasswordHandler) CheckOut(ctx context.Context, storage logical.Storage,
 // 		- An error will be returned.
 //		- The account will remain checked out.
 //		- The client may (or may not) retry the check-in.
-// 		- The overdue watcher will still check it in if its lending period runs out.
+// 		- The overdue watcher will still check it in if its ttl runs out.
 func (h *PasswordHandler) CheckIn(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
 	if err := validateInputs(ctx, storage, serviceAccountName, nil, false); err != nil {
 		return err

--- a/plugin/checkout_handlers_test.go
+++ b/plugin/checkout_handlers_test.go
@@ -17,7 +17,6 @@ func setup() (context.Context, logical.Storage, string, *CheckOut) {
 	checkOut := &CheckOut{
 		BorrowerEntityID:    "entity-id",
 		BorrowerClientToken: "client-token",
-		LendingPeriod:       10,
 		Due:                 time.Now().UTC(),
 	}
 	config := &configuration{

--- a/plugin/path_checkouts.go
+++ b/plugin/path_checkouts.go
@@ -62,7 +62,6 @@ func (b *backend) operationReserveStatus(ctx context.Context, req *logical.Reque
 			respData[serviceAccountName] = status
 			continue
 		}
-		status["lending_period"] = int64(checkOut.LendingPeriod.Seconds())
 		status["due"] = checkOut.Due.Format(time.RFC3339Nano)
 		if checkOut.BorrowerClientToken != "" {
 			status["borrower_client_token"] = checkOut.BorrowerClientToken


### PR DESCRIPTION
This PR replaces `lending_period` with `ttl` and `max_ttl`. This will allow us to leverage the existing leasing system for expiring and renewing check-outs.