### PR TITLE
Add check-out, check-in, renewal, revocation, and race protection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           echo 'export GO111MODULE=on' >> $BASH_ENV
     - run:
         name: "Run Tests"
-        command: make test
+        command: make testrace
     - run:
         name: "Install Gox"
         command: go get github.com/mitchellh/gox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
         command: |
           echo 'export GO111MODULE=on' >> $BASH_ENV
     - run:
-        name: "Run Tests"
+        name: "Run All Tests with Race Detection"
         command: make testrace
     - run:
         name: "Install Gox"

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,12 @@ dev: fmtcheck generate
 	@CGO_ENABLED=0 BUILD_TAGS='$(BUILD_TAGS)' VAULT_DEV_BUILD=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 
 # testshort runs the quick unit tests and vets the code
-testshort: fmtcheck generate
+test: fmtcheck generate
 	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -v -short -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4
 
 # test runs the unit tests and vets the code
-test: fmtcheck generate
-	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -v -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4
+testrace: fmtcheck generate
+	CGO_ENABLED=1 VAULT_TOKEN= VAULT_ACC= go test -race -v -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -count=1 -timeout=20m -parallel=4
 
 testcompile: fmtcheck generate
 	@for pkg in $(TEST) ; do \

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -47,8 +47,8 @@ func newBackend(client secretsClient) *backend {
 			adBackend.pathSetManageCheckIn(),
 			adBackend.pathSetCheckOut(),
 			adBackend.pathSetStatus(),
-			adBackend.pathReserves(),
-			adBackend.pathListReserves(),
+			adBackend.pathSets(),
+			adBackend.pathListSets(),
 		},
 		PathsSpecial: &logical.Paths{
 			SealWrapStorage: []string{

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"sync"
 	"time"
 
@@ -30,6 +31,7 @@ func newBackend(client secretsClient) *backend {
 			client: client,
 			child:  &StorageHandler{},
 		},
+		checkOutLocks: locksutil.CreateLocks(),
 	}
 	adBackend.Backend = &framework.Backend{
 		Help: backendHelp,
@@ -74,6 +76,9 @@ type backend struct {
 	rotateRootLock *int32
 
 	checkOutHandler CheckOutHandler
+	// checkOutLocks are used for avoiding races
+	// when working with service accounts through the check-out system.
+	checkOutLocks []*locksutil.LockEntry
 }
 
 func (b *backend) Invalidate(ctx context.Context, key string) {

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -41,7 +41,10 @@ func newBackend(client secretsClient) *backend {
 			adBackend.pathRotateCredentials(),
 
 			// The following paths are for AD credential checkout.
-			adBackend.pathReserveStatus(),
+			adBackend.pathSetCheckIn(),
+			adBackend.pathSetManageCheckIn(),
+			adBackend.pathSetCheckOut(),
+			adBackend.pathSetStatus(),
 			adBackend.pathReserves(),
 			adBackend.pathListReserves(),
 		},
@@ -53,12 +56,15 @@ func newBackend(client secretsClient) *backend {
 		},
 		Invalidate:  adBackend.Invalidate,
 		BackendType: logical.TypeLogical,
+		Secrets: []*framework.Secret{
+			adBackend.secretAccessKeys(),
+		},
 	}
 	return adBackend
 }
 
 type backend struct {
-	logical.Backend
+	*framework.Backend
 
 	client secretsClient
 

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -77,7 +77,7 @@ type backend struct {
 
 	checkOutHandler CheckOutHandler
 	// checkOutLocks are used for avoiding races
-	// when working with service accounts through the check-out system.
+	// when working with sets through the check-out system.
 	checkOutLocks []*locksutil.LockEntry
 }
 

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -2,13 +2,13 @@ package plugin
 
 import (
 	"context"
-	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"sync"
 	"time"
 
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/patrickmn/go-cache"
 )

--- a/plugin/backend_checkouts_test.go
+++ b/plugin/backend_checkouts_test.go
@@ -157,11 +157,11 @@ func TestCheckOutRaces(t *testing.T) {
 	close(start)
 
 	// Wait for them all to finish.
-	timer := time.NewTimer(10 * time.Second)
+	timer := time.NewTimer(15 * time.Second)
 	for i := 0; i < numParallel; i++ {
 		select {
 		case <-timer.C:
-			t.Fatal("test took more than 10 seconds, may be deadlocked")
+			t.Fatal("test took more than 15 seconds, may be deadlocked")
 		case <-end:
 			continue
 		}

--- a/plugin/backend_checkouts_test.go
+++ b/plugin/backend_checkouts_test.go
@@ -218,7 +218,7 @@ func ListReserves(t *testing.T) {
 		t.Fatalf("expected 1 key but received %s", listedKeys)
 	}
 	if "test-set" != listedKeys[0] {
-		t.Fatal("expected test-check-out set to be the only listed item")
+		t.Fatal("expected test-set to be the only listed item")
 	}
 }
 

--- a/plugin/backend_checkouts_test.go
+++ b/plugin/backend_checkouts_test.go
@@ -416,7 +416,7 @@ func CheckInitialStatus(t *testing.T) {
 
 func PerformCheckOut(t *testing.T) {
 	req := &logical.Request{
-		Operation: logical.ReadOperation,
+		Operation: logical.UpdateOperation,
 		Path:      libraryPrefix + "test-set/check-out",
 		Storage:   testStorage,
 	}
@@ -490,7 +490,7 @@ func CheckUpdatedStatus(t *testing.T) {
 
 func NormalCheckIn(t *testing.T) {
 	req := &logical.Request{
-		Operation: logical.ReadOperation,
+		Operation: logical.UpdateOperation,
 		Path:      libraryPrefix + "test-set/check-in",
 		Storage:   testStorage,
 	}
@@ -509,7 +509,7 @@ func NormalCheckIn(t *testing.T) {
 
 func ForceCheckIn(t *testing.T) {
 	req := &logical.Request{
-		Operation: logical.ReadOperation,
+		Operation: logical.UpdateOperation,
 		Path:      libraryPrefix + "manage/test-set/check-in",
 		Storage:   testStorage,
 	}

--- a/plugin/backend_checkouts_test.go
+++ b/plugin/backend_checkouts_test.go
@@ -13,18 +13,18 @@ func TestCheckOuts(t *testing.T) {
 	// Plant a config.
 	t.Run("plant config", PlantConfig)
 
-	// Exercise all reserve endpoints.
-	t.Run("write reserve", WriteReserve)
-	t.Run("read reserve", ReadReserve)
-	t.Run("read reserve status", ReadReserveStatus)
-	t.Run("write reserve toggle off", WriteReserveToggleOff)
-	t.Run("read reserve toggle off", ReadReserveToggleOff)
-	t.Run("write conflicting reserve", WriteReserveWithConflictingServiceAccounts)
-	t.Run("list reserves", ListReserves)
-	t.Run("delete reserve", DeleteReserve)
+	// Exercise all set endpoints.
+	t.Run("write set", WriteReserve)
+	t.Run("read set", ReadReserve)
+	t.Run("read set status", ReadReserveStatus)
+	t.Run("write set toggle off", WriteReserveToggleOff)
+	t.Run("read set toggle off", ReadReserveToggleOff)
+	t.Run("write conflicting set", WriteReserveWithConflictingServiceAccounts)
+	t.Run("list sets", ListReserves)
+	t.Run("delete set", DeleteReserve)
 
-	// Do some common updates on reserves and ensure they work.
-	t.Run("write reserve", WriteReserve)
+	// Do some common updates on sets and ensure they work.
+	t.Run("write set", WriteReserve)
 	t.Run("add service account", AddAnotherServiceAccount)
 	t.Run("remove service account", RemoveServiceAccount)
 }
@@ -32,7 +32,7 @@ func TestCheckOuts(t *testing.T) {
 func WriteReserve(t *testing.T) {
 	req := &logical.Request{
 		Operation: logical.CreateOperation,
-		Path:      libraryPrefix + "test-reserve",
+		Path:      libraryPrefix + "test-set",
 		Storage:   testStorage,
 		Data: map[string]interface{}{
 			"service_account_names":        []string{"tester1@example.com", "tester2@example.com"},
@@ -53,7 +53,7 @@ func WriteReserve(t *testing.T) {
 func AddAnotherServiceAccount(t *testing.T) {
 	req := &logical.Request{
 		Operation: logical.UpdateOperation,
-		Path:      libraryPrefix + "test-reserve",
+		Path:      libraryPrefix + "test-set",
 		Storage:   testStorage,
 		Data: map[string]interface{}{
 			"service_account_names": []string{"tester1@example.com", "tester2@example.com", "tester3@example.com"},
@@ -71,7 +71,7 @@ func AddAnotherServiceAccount(t *testing.T) {
 func RemoveServiceAccount(t *testing.T) {
 	req := &logical.Request{
 		Operation: logical.UpdateOperation,
-		Path:      libraryPrefix + "test-reserve",
+		Path:      libraryPrefix + "test-set",
 		Storage:   testStorage,
 		Data: map[string]interface{}{
 			"service_account_names": []string{"tester1@example.com", "tester2@example.com"},
@@ -89,7 +89,7 @@ func RemoveServiceAccount(t *testing.T) {
 func ReadReserve(t *testing.T) {
 	req := &logical.Request{
 		Operation: logical.ReadOperation,
-		Path:      libraryPrefix + "test-reserve",
+		Path:      libraryPrefix + "test-set",
 		Storage:   testStorage,
 	}
 	resp, err := testBackend.HandleRequest(ctx, req)
@@ -120,7 +120,7 @@ func ReadReserve(t *testing.T) {
 func WriteReserveToggleOff(t *testing.T) {
 	req := &logical.Request{
 		Operation: logical.UpdateOperation,
-		Path:      libraryPrefix + "test-reserve",
+		Path:      libraryPrefix + "test-set",
 		Storage:   testStorage,
 		Data: map[string]interface{}{
 			"service_account_names":        []string{"tester1@example.com", "tester2@example.com"},
@@ -140,7 +140,7 @@ func WriteReserveToggleOff(t *testing.T) {
 func ReadReserveToggleOff(t *testing.T) {
 	req := &logical.Request{
 		Operation: logical.ReadOperation,
-		Path:      libraryPrefix + "test-reserve",
+		Path:      libraryPrefix + "test-set",
 		Storage:   testStorage,
 	}
 	resp, err := testBackend.HandleRequest(ctx, req)
@@ -163,7 +163,7 @@ func ReadReserveToggleOff(t *testing.T) {
 func ReadReserveStatus(t *testing.T) {
 	req := &logical.Request{
 		Operation: logical.ReadOperation,
-		Path:      libraryPrefix + "test-reserve/status",
+		Path:      libraryPrefix + "test-set/status",
 		Storage:   testStorage,
 	}
 	resp, err := testBackend.HandleRequest(ctx, req)
@@ -174,7 +174,7 @@ func ReadReserveStatus(t *testing.T) {
 		t.Fatal("expected a response")
 	}
 	if len(resp.Data) != 2 {
-		t.Fatal("length should be 2 because there are two service accounts in this reserve")
+		t.Fatal("length should be 2 because there are two service accounts in this set")
 	}
 	testerStatus := resp.Data["tester1@example.com"].(map[string]interface{})
 	if !testerStatus["available"].(bool) {
@@ -185,7 +185,7 @@ func ReadReserveStatus(t *testing.T) {
 func WriteReserveWithConflictingServiceAccounts(t *testing.T) {
 	req := &logical.Request{
 		Operation: logical.CreateOperation,
-		Path:      libraryPrefix + "test-reserve2",
+		Path:      libraryPrefix + "test-set2",
 		Storage:   testStorage,
 		Data: map[string]interface{}{
 			"service_account_names": "tester1@example.com",
@@ -196,7 +196,7 @@ func WriteReserveWithConflictingServiceAccounts(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatal("expected err response because we're adding a service account managed by another reserve")
+		t.Fatal("expected err response because we're adding a service account managed by another set")
 	}
 }
 
@@ -217,15 +217,15 @@ func ListReserves(t *testing.T) {
 	if len(listedKeys) != 1 {
 		t.Fatalf("expected 1 key but received %s", listedKeys)
 	}
-	if "test-reserve" != listedKeys[0] {
-		t.Fatal("expected test-reserve to be the only listed item")
+	if "test-set" != listedKeys[0] {
+		t.Fatal("expected test-check-out set to be the only listed item")
 	}
 }
 
 func DeleteReserve(t *testing.T) {
 	req := &logical.Request{
 		Operation: logical.DeleteOperation,
-		Path:      libraryPrefix + "test-reserve",
+		Path:      libraryPrefix + "test-set",
 		Storage:   testStorage,
 	}
 	resp, err := testBackend.HandleRequest(ctx, req)

--- a/plugin/checkout_handlers.go
+++ b/plugin/checkout_handlers.go
@@ -16,6 +16,10 @@ var (
 	// for a service account that's already checked out.
 	ErrCurrentlyCheckedOut = errors.New("currently checked out")
 
+	// ErrNotCurrentlyCheckedOut is returned when a renewal request is received
+	// for a service account that's not currently checked out.
+	ErrNotCurrentlyCheckedOut = errors.New("not currently checked out")
+
 	// ErrNotFound is used when a requested item doesn't exist.
 	ErrNotFound = errors.New("not found")
 )
@@ -29,6 +33,7 @@ type CheckOut struct {
 	Due                 time.Time `json:"due"`
 }
 
+// TODO this object model needs to be flattened and moved to its own package if some methods need to remain private
 // CheckOutHandler is an interface used to break down tasks involved in managing checkouts. These tasks
 // are many and can be complex, so it helps to break them down into small, easily testable units
 // that help us build our confidence in the code.
@@ -37,6 +42,9 @@ type CheckOutHandler interface {
 	// ErrCurrentlyCheckedOut. If the service account isn't managed by this plugin, it returns
 	// ErrNotFound.
 	CheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error
+
+	// Renew will renew a check-out for the given period from now.
+	Renew(ctx context.Context, storage logical.Storage, serviceAccountName string, updatedCheckOut *CheckOut) error
 
 	// CheckIn attempts to check in a service account. If an error occurs, the account remains checked out
 	// and can either be retried by the caller, or eventually may be checked in if it has a ttl
@@ -61,6 +69,10 @@ type PasswordHandler struct {
 // CheckOut requires no further action from the password handler other than passing along the request.
 func (h *PasswordHandler) CheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string, checkOut *CheckOut) error {
 	return h.child.CheckOut(ctx, storage, serviceAccountName, checkOut)
+}
+
+func (h *PasswordHandler) Renew(ctx context.Context, storage logical.Storage, serviceAccountName string, updatedCheckOut *CheckOut) error {
+	return h.child.Renew(ctx, storage, serviceAccountName, updatedCheckOut)
 }
 
 // CheckIn rotates the service account's password remotely and stores it locally.
@@ -166,6 +178,30 @@ func (h *StorageHandler) CheckOut(ctx context.Context, storage logical.Storage, 
 		return err
 	}
 	return storage.Put(ctx, entry)
+}
+
+func (h *StorageHandler) Renew(ctx context.Context, storage logical.Storage, serviceAccountName string, updatedCheckOut *CheckOut) error {
+	// Check if the service account is currently checked out.
+	if entry, err := storage.Get(ctx, checkoutStoragePrefix+serviceAccountName); err != nil {
+		return err
+	} else if entry == nil {
+		return ErrNotFound
+	} else {
+		currentCheckOut := &CheckOut{}
+		if err := entry.DecodeJSON(currentCheckOut); err != nil {
+			return err
+		}
+		// We can't renew something unless it's currently checked out.
+		if currentCheckOut.IsAvailable {
+			return ErrNotCurrentlyCheckedOut
+		}
+		// Store the updated check-out.
+		entry, err := logical.StorageEntryJSON(checkoutStoragePrefix+serviceAccountName, updatedCheckOut)
+		if err != nil {
+			return err
+		}
+		return storage.Put(ctx, entry)
+	}
 }
 
 // CheckIn will return nil error if it was able to successfully check in an account.

--- a/plugin/checkout_handlers.go
+++ b/plugin/checkout_handlers.go
@@ -3,8 +3,6 @@ package plugin
 import (
 	"context"
 	"errors"
-	"time"
-
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/util"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -27,10 +25,9 @@ var (
 // CheckOut provides information for a service account that is currently
 // checked out.
 type CheckOut struct {
-	IsAvailable         bool      `json:"is_available"`
-	BorrowerEntityID    string    `json:"borrower_entity_id"`
-	BorrowerClientToken string    `json:"borrower_client_token"`
-	Due                 time.Time `json:"due"`
+	IsAvailable         bool   `json:"is_available"`
+	BorrowerEntityID    string `json:"borrower_entity_id"`
+	BorrowerClientToken string `json:"borrower_client_token"`
 }
 
 // TODO this object model needs to be flattened and moved to its own package if some methods need to remain private

--- a/plugin/checkout_handlers_test.go
+++ b/plugin/checkout_handlers_test.go
@@ -172,6 +172,10 @@ func (f *fakeCheckOutHandler) CheckOut(ctx context.Context, storage logical.Stor
 	return nil
 }
 
+func (f *fakeCheckOutHandler) Renew(ctx context.Context, storage logical.Storage, serviceAccountName string, updatedCheckOut *CheckOut) error {
+	return nil
+}
+
 func (f *fakeCheckOutHandler) CheckIn(ctx context.Context, storage logical.Storage, serviceAccountName string) error {
 	return nil
 }

--- a/plugin/checkout_handlers_test.go
+++ b/plugin/checkout_handlers_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -17,7 +16,6 @@ func setup() (context.Context, logical.Storage, string, *CheckOut) {
 	checkOut := &CheckOut{
 		BorrowerEntityID:    "entity-id",
 		BorrowerClientToken: "client-token",
-		Due:                 time.Now().UTC(),
 	}
 	config := &configuration{
 		PasswordConf: &passwordConf{

--- a/plugin/checkout_handlers_test.go
+++ b/plugin/checkout_handlers_test.go
@@ -65,8 +65,8 @@ func Test_StorageHandler(t *testing.T) {
 	// get a CurrentlyCheckedOutErr.
 	if err := storageHandler.CheckOut(ctx, storage, serviceAccountName, testCheckOut); err == nil {
 		t.Fatal("expected err but received none")
-	} else if err != ErrCurrentlyCheckedOut {
-		t.Fatalf("expected ErrCurrentlyCheckedOut, but received %s", err)
+	} else if err != ErrCheckedOut {
+		t.Fatalf("expected ErrCheckedOut, but received %s", err)
 	}
 
 	// If we try to check something in, it should succeed.

--- a/plugin/path_checkout_sets.go
+++ b/plugin/path_checkout_sets.go
@@ -263,8 +263,7 @@ func (b *backend) operationReserveRead(ctx context.Context, req *logical.Request
 	if set == nil {
 		return nil, nil
 	}
-
-	// We don't worry about grabbing read locks for service accounts here because we expect this
+	
 	// We don't worry about grabbing read locks for service accounts here because we expect this
 	// call to be rare and initiates by humans, and it's okay if it's not perfectly
 	// consistent since it's not performing any changes.

--- a/plugin/path_checkout_sets.go
+++ b/plugin/path_checkout_sets.go
@@ -233,9 +233,6 @@ func (b *backend) operationReserveUpdate(ctx context.Context, req *logical.Reque
 	if ttlSent {
 		set.TTL = ttl
 	}
-	if ttlSent {
-		set.TTL = ttl
-	}
 	if maxTTLSent {
 		set.MaxTTL = maxTTL
 	}

--- a/plugin/path_checkout_sets.go
+++ b/plugin/path_checkout_sets.go
@@ -263,7 +263,7 @@ func (b *backend) operationReserveRead(ctx context.Context, req *logical.Request
 	if set == nil {
 		return nil, nil
 	}
-	
+
 	// We don't worry about grabbing read locks for service accounts here because we expect this
 	// call to be rare and initiates by humans, and it's okay if it's not perfectly
 	// consistent since it's not performing any changes.

--- a/plugin/path_checkouts.go
+++ b/plugin/path_checkouts.go
@@ -300,7 +300,7 @@ func (b *backend) handleCheckIn(ctx context.Context, req *logical.Request, field
 				continue
 			}
 			if !canCheckIn(req, checkOut, disableCheckInEnforcement) {
-				cantCheckInErrs = multierror.Append(cantCheckInErrs, fmt.Errorf(`"%s" can't be checked in because it wasn't checked out by the caller, please remove it and try again`, serviceAccountName))
+				cantCheckInErrs = multierror.Append(cantCheckInErrs, fmt.Errorf(`"%s" can't be checked in because it wasn't checked out by the caller`, serviceAccountName))
 				continue
 			}
 			toCheckIn = append(toCheckIn, serviceAccountName)

--- a/plugin/path_checkouts.go
+++ b/plugin/path_checkouts.go
@@ -24,7 +24,7 @@ func (b *backend) pathSetCheckOut() *framework.Path {
 			},
 			"ttl": {
 				Type:        framework.TypeDurationSecond,
-				Description: "In seconds, the length of time before the check-out will expire.",
+				Description: "The length of time before the check-out will expire, in seconds.",
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{

--- a/plugin/path_checkouts.go
+++ b/plugin/path_checkouts.go
@@ -328,7 +328,7 @@ func (b *backend) operationSetStatus(ctx context.Context, req *logical.Request, 
 		return logical.ErrorResponse(fmt.Sprintf(`%q doesn't exist`, setName)), nil
 	}
 	respData := make(map[string]interface{})
-	
+
 	for _, serviceAccountName := range set.ServiceAccountNames {
 		checkOut, err := b.checkOutHandler.Status(ctx, req.Storage, serviceAccountName)
 		if err != nil {

--- a/plugin/path_checkouts.go
+++ b/plugin/path_checkouts.go
@@ -328,10 +328,7 @@ func (b *backend) operationSetStatus(ctx context.Context, req *logical.Request, 
 		return logical.ErrorResponse(fmt.Sprintf(`%q doesn't exist`, setName)), nil
 	}
 	respData := make(map[string]interface{})
-
-	// We don't worry about grabbing read locks for these because we expect this
-	// call to be rare and initiates by humans, and it's okay if it's not perfectly
-	// consistent since it's not performing any changes.
+	
 	for _, serviceAccountName := range set.ServiceAccountNames {
 		checkOut, err := b.checkOutHandler.Status(ctx, req.Storage, serviceAccountName)
 		if err != nil {

--- a/plugin/path_checkouts.go
+++ b/plugin/path_checkouts.go
@@ -15,14 +15,14 @@ func (b *backend) pathReserveStatus() *framework.Path {
 		Fields: map[string]*framework.FieldSchema{
 			"name": {
 				Type:        framework.TypeLowerCaseString,
-				Description: "Name of the reserve",
+				Description: "Name of the set.",
 				Required:    true,
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.operationReserveStatus,
-				Summary:  "Check the status of the service accounts in a library reserve.",
+				Summary:  "Check the status of the service accounts in a library set.",
 			},
 		},
 		HelpSynopsis: `Check the status of the service accounts in a library.`,
@@ -30,16 +30,16 @@ func (b *backend) pathReserveStatus() *framework.Path {
 }
 
 func (b *backend) operationReserveStatus(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
-	reserveName := fieldData.Get("name").(string)
-	reserve, err := readReserve(ctx, req.Storage, reserveName)
+	setName := fieldData.Get("name").(string)
+	set, err := readSet(ctx, req.Storage, setName)
 	if err != nil {
 		return nil, err
 	}
-	if reserve == nil {
-		return logical.ErrorResponse(`"%s" doesn't exist`, reserveName), nil
+	if set == nil {
+		return logical.ErrorResponse(`"%s" doesn't exist`, setName), nil
 	}
 	respData := make(map[string]interface{})
-	for _, serviceAccountName := range reserve.ServiceAccountNames {
+	for _, serviceAccountName := range set.ServiceAccountNames {
 		checkOut, err := b.checkOutHandler.Status(ctx, req.Storage, serviceAccountName)
 		if err != nil {
 			return nil, err

--- a/plugin/path_checkouts.go
+++ b/plugin/path_checkouts.go
@@ -295,7 +295,7 @@ func (b *backend) handleCheckIn(ctx context.Context, req *logical.Request, field
 			// Everything's already currently checked in, nothing else to do here.
 		case 1:
 			// This is what we need to continue with the check-in process.
-			for serviceAccountName, _ := range toCheckIn {
+			for serviceAccountName := range toCheckIn {
 				if err := b.checkOutHandler.CheckIn(ctx, req.Storage, serviceAccountName); err != nil {
 					return nil, err
 				}

--- a/plugin/path_checkouts.go
+++ b/plugin/path_checkouts.go
@@ -5,11 +5,320 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func (b *backend) pathReserveStatus() *framework.Path {
+const secretAccessKeyType = "creds"
+
+// TODO we're going to need to deal with mutexes.
+func (b *backend) pathSetCheckOut() *framework.Path {
+	return &framework.Path{
+		Pattern: libraryPrefix + framework.GenericNameRegex("name") + "/check-out$",
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeLowerCaseString,
+				Description: "Name of the set",
+				Required:    true,
+			},
+			"ttl": {
+				Type:        framework.TypeDurationSecond,
+				Description: "In seconds, the length of time before the check-out will expire.",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.operationSetCheckOut,
+				Summary:  "Check a service account out from the library.",
+			},
+		},
+		HelpSynopsis: `Check a service account out from the library.`,
+	}
+}
+
+func (b *backend) operationSetCheckOut(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+	setName := fieldData.Get("name").(string)
+
+	ttlPeriodRaw, ttlPeriodSent := fieldData.GetOk("ttl")
+	if !ttlPeriodSent {
+		ttlPeriodRaw = 0
+	}
+	requestedTTL := time.Duration(ttlPeriodRaw.(int)) * time.Second
+
+	set, err := readSet(ctx, req.Storage, setName)
+	if err != nil {
+		return nil, err
+	}
+	if set == nil {
+		return logical.ErrorResponse(`"%s" doesn't exist`, setName), nil
+	}
+
+	// Find the first service account available.
+	var availableServiceAccountName string
+	for _, serviceAccountName := range set.ServiceAccountNames {
+		checkOut, err := b.checkOutHandler.Status(ctx, req.Storage, serviceAccountName)
+		if err != nil {
+			return nil, err
+		}
+		if checkOut.IsAvailable {
+			availableServiceAccountName = serviceAccountName
+			break
+		}
+	}
+	if availableServiceAccountName == "" {
+		resp, err := logical.RespondWithStatusCode(&logical.Response{
+			Warnings: []string{"No service accounts available for check-out, please try again later."},
+		}, req, 429)
+		if err != nil {
+			return nil, err
+		}
+		return resp, nil
+	}
+	ttl := set.TTL
+	if ttlPeriodSent {
+		switch {
+		case set.TTL <= 0 && requestedTTL > 0:
+			// The set's TTL is infinite and the caller requested a finite TTL.
+			ttl = requestedTTL
+		case set.TTL > 0 && requestedTTL < set.TTL:
+			// The set's TTL isn't infinite and the caller requested a shorter TTL.
+			ttl = requestedTTL
+		}
+	}
+	due := time.Now().UTC().Add(ttl)
+	if ttl <= 0 {
+		// An unlimited lending period is allowed. For simplicity, set
+		// the due date to be 100 years in the future.
+		// The due date is mainly for use during "status" calls so it's
+		// easy to understand who has checked something out and for how long.
+		due = time.Now().UTC().Add(time.Hour * 24 * 365 * 100)
+	}
+	checkOut := &CheckOut{
+		IsAvailable:         false,
+		Due:                 due,
+		BorrowerEntityID:    req.EntityID,
+		BorrowerClientToken: req.ClientToken,
+	}
+
+	if err := b.checkOutHandler.CheckOut(ctx, req.Storage, availableServiceAccountName, checkOut); err != nil {
+		return nil, err
+	}
+	password, err := retrievePassword(ctx, req.Storage, availableServiceAccountName)
+	if err != nil {
+		return nil, err
+	}
+
+	respData := map[string]interface{}{
+		"service_account_name": availableServiceAccountName,
+		"password":             password,
+	}
+	internalData := map[string]interface{}{
+		"set_name":             setName,
+		"service_account_name": availableServiceAccountName,
+	}
+	resp := b.Backend.Secret(secretAccessKeyType).Response(respData, internalData)
+	resp.Secret.Renewable = true
+	resp.Secret.TTL = ttl
+	resp.Secret.MaxTTL = set.MaxTTL
+	return resp, nil
+}
+
+func (b *backend) secretAccessKeys() *framework.Secret {
+	return &framework.Secret{
+		Type: secretAccessKeyType,
+		Fields: map[string]*framework.FieldSchema{
+			"service_account_name": {
+				Type:        framework.TypeString,
+				Description: "Access Key",
+			},
+			"password": {
+				Type:        framework.TypeString,
+				Description: "Secret Key",
+			},
+		},
+		Renew:  b.renewCheckOut,
+		Revoke: b.endCheckOut,
+	}
+}
+
+func (b *backend) renewCheckOut(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+	setName := req.Secret.InternalData["set_name"].(string)
+	serviceAccountName := req.Secret.InternalData["service_account_name"].(string)
+
+	checkOut, err := b.checkOutHandler.Status(ctx, req.Storage, serviceAccountName)
+	if err != nil {
+		return nil, err
+	}
+	if checkOut.IsAvailable {
+		// It's possible that this renewal could be attempted after a check-in occurred either by this entity or by
+		// another user with access to the "manage check-ins" endpoint that forcibly checked it back in.
+		return logical.ErrorResponse(fmt.Sprintf("%s is already checked in, please call check-out to regain it", serviceAccountName)), nil
+	}
+
+	set, err := readSet(ctx, req.Storage, setName)
+	if err != nil {
+		return nil, err
+	}
+	if set == nil {
+		return logical.ErrorResponse(`"%s" doesn't exist`, setName), nil
+	}
+	// The new time due will be consistent with when the secret ttl ends.
+	checkOut.Due = time.Now().UTC().Add(req.Secret.TTL)
+
+	// Try to renew it for however long the checkout was originally set to last, unless the set lending period
+	// has been shortened.
+	if err := b.checkOutHandler.Renew(ctx, req.Storage, serviceAccountName, checkOut); err != nil {
+		return nil, err
+	}
+	return &logical.Response{Secret: req.Secret}, nil
+}
+
+func (b *backend) endCheckOut(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+	serviceAccountName := req.Secret.InternalData["service_account_name"].(string)
+	if err := b.checkOutHandler.CheckIn(ctx, req.Storage, serviceAccountName); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (b *backend) pathSetCheckIn() *framework.Path {
+	return &framework.Path{
+		Pattern: libraryPrefix + framework.GenericNameRegex("name") + "/check-in$",
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeLowerCaseString,
+				Description: "Name of the set.",
+				Required:    true,
+			},
+			"service_account_names": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: "The username/logon name for the service accounts to check in.",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.operationSetCheckIn,
+				Summary:  "Check service accounts in to the library.",
+			},
+		},
+		HelpSynopsis: `Check service accounts in to the library.`,
+	}
+}
+
+func (b *backend) operationSetCheckIn(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+	return b.handleCheckIn(ctx, req, fieldData, false)
+}
+
+func (b *backend) pathSetManageCheckIn() *framework.Path {
+	return &framework.Path{
+		Pattern: libraryPrefix + "manage/" + framework.GenericNameRegex("name") + "/check-in$",
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeLowerCaseString,
+				Description: "Name of the set.",
+				Required:    true,
+			},
+			"service_account_names": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: "The username/logon name for the service accounts to check in.",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.operationSetManageCheckIn,
+				Summary:  "Check service accounts in to the library.",
+			},
+		},
+		HelpSynopsis: `Force checking service accounts in to the library.`,
+	}
+}
+
+func (b *backend) operationSetManageCheckIn(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+	return b.handleCheckIn(ctx, req, fieldData, true)
+}
+
+func (b *backend) handleCheckIn(ctx context.Context, req *logical.Request, fieldData *framework.FieldData, overrideCheckInEnforcement bool) (*logical.Response, error) {
+	setName := fieldData.Get("name").(string)
+
+	serviceAccountNamesRaw, serviceAccountNamesSent := fieldData.GetOk("service_account_names")
+	var serviceAccountNames []string
+	if serviceAccountNamesSent {
+		serviceAccountNames = serviceAccountNamesRaw.([]string)
+	}
+
+	set, err := readSet(ctx, req.Storage, setName)
+	if err != nil {
+		return nil, err
+	}
+
+	// If check-in enforcement is overridden or disabled at the set level, we should consider it disabled.
+	disableCheckInEnforcement := overrideCheckInEnforcement || set.DisableCheckInEnforcement
+
+	respData := map[string]interface{}{
+		"check_ins": make([]string, 0),
+	}
+
+	// Build and validate a list of service account names that we will be checking in.
+	if len(serviceAccountNames) == 0 {
+		// It's okay if the caller doesn't tell us which service accounts they
+		// want to check in as long as they only have one checked out.
+		// We'll assume that's the one they want to check in.
+		for _, setServiceAccount := range set.ServiceAccountNames {
+			checkOut, err := b.checkOutHandler.Status(ctx, req.Storage, setServiceAccount)
+			if err != nil {
+				return nil, err
+			}
+			if checkOut.IsAvailable {
+				continue
+			}
+			if !canCheckIn(req, checkOut, disableCheckInEnforcement) {
+				continue
+			}
+			serviceAccountNames = append(serviceAccountNames, setServiceAccount)
+		}
+		switch len(serviceAccountNames) {
+		case 0:
+			// Everything's already currently checked in, nothing else to do here.
+			return &logical.Response{
+				Data: respData,
+			}, nil
+		case 1:
+			// This is what we need to continue with the check-in process.
+		default:
+			return logical.ErrorResponse(`when multiple service accounts are checked out, the "service_account_names" to check in must be provided`), nil
+		}
+	} else {
+		var cantCheckInErrs error
+		for _, serviceAccountName := range serviceAccountNames {
+			checkOut, err := b.checkOutHandler.Status(ctx, req.Storage, serviceAccountName)
+			if err != nil {
+				return nil, err
+			}
+			if !checkOut.IsAvailable {
+				continue
+			}
+			if !canCheckIn(req, checkOut, disableCheckInEnforcement) {
+				cantCheckInErrs = multierror.Append(cantCheckInErrs, fmt.Errorf(`"%s" can't be checked in because it wasn't checked out by the caller, please remove it and try again`, serviceAccountName))
+			}
+		}
+		if cantCheckInErrs != nil {
+			return logical.ErrorResponse(cantCheckInErrs.Error()), nil
+		}
+	}
+
+	respData["check_ins"] = serviceAccountNames
+	for _, serviceAccountName := range serviceAccountNames {
+		if err := b.checkOutHandler.CheckIn(ctx, req.Storage, serviceAccountName); err != nil {
+			return nil, err
+		}
+	}
+	return &logical.Response{
+		Data: respData,
+	}, nil
+}
+
+func (b *backend) pathSetStatus() *framework.Path {
 	return &framework.Path{
 		Pattern: libraryPrefix + framework.GenericNameRegex("name") + "/status$",
 		Fields: map[string]*framework.FieldSchema{
@@ -21,7 +330,7 @@ func (b *backend) pathReserveStatus() *framework.Path {
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
-				Callback: b.operationReserveStatus,
+				Callback: b.operationSetStatus,
 				Summary:  "Check the status of the service accounts in a library set.",
 			},
 		},
@@ -29,7 +338,7 @@ func (b *backend) pathReserveStatus() *framework.Path {
 	}
 }
 
-func (b *backend) operationReserveStatus(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+func (b *backend) operationSetStatus(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
 	setName := fieldData.Get("name").(string)
 	set, err := readSet(ctx, req.Storage, setName)
 	if err != nil {
@@ -44,14 +353,6 @@ func (b *backend) operationReserveStatus(ctx context.Context, req *logical.Reque
 		if err != nil {
 			return nil, err
 		}
-		if checkOut == nil {
-			// This should never happen because for every service account, it should have
-			// been checked in when it was first created.
-			b.Logger().Warn(fmt.Sprintf("%s should have been checked in, but wasn't, checking it in now", serviceAccountName))
-			if err := b.checkOutHandler.CheckIn(ctx, req.Storage, serviceAccountName); err != nil {
-				return nil, err
-			}
-		}
 
 		status := map[string]interface{}{
 			"available": checkOut.IsAvailable,
@@ -65,7 +366,8 @@ func (b *backend) operationReserveStatus(ctx context.Context, req *logical.Reque
 		status["due"] = checkOut.Due.Format(time.RFC3339Nano)
 		if checkOut.BorrowerClientToken != "" {
 			status["borrower_client_token"] = checkOut.BorrowerClientToken
-		} else {
+		}
+		if checkOut.BorrowerEntityID != "" {
 			status["borrower_entity_id"] = checkOut.BorrowerEntityID
 		}
 		respData[serviceAccountName] = status
@@ -73,4 +375,21 @@ func (b *backend) operationReserveStatus(ctx context.Context, req *logical.Reque
 	return &logical.Response{
 		Data: respData,
 	}, nil
+}
+
+func canCheckIn(req *logical.Request, checkOut *CheckOut, disableCheckInEnforcement bool) bool {
+	if disableCheckInEnforcement {
+		return true
+	}
+	if checkOut.BorrowerEntityID != "" && req.EntityID != "" {
+		if checkOut.BorrowerEntityID == req.EntityID {
+			return true
+		}
+	}
+	if checkOut.BorrowerClientToken != "" && req.ClientToken != "" {
+		if checkOut.BorrowerClientToken == req.ClientToken {
+			return true
+		}
+	}
+	return false
 }

--- a/plugin/path_checkouts.go
+++ b/plugin/path_checkouts.go
@@ -27,7 +27,7 @@ func (b *backend) pathSetCheckOut() *framework.Path {
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.ReadOperation: &framework.PathOperation{
+			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.operationSetCheckOut,
 				Summary:  "Check a service account out from the library.",
 			},
@@ -173,7 +173,7 @@ func (b *backend) pathSetCheckIn() *framework.Path {
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.ReadOperation: &framework.PathOperation{
+			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.operationCheckIn(false),
 				Summary:  "Check service accounts in to the library.",
 			},
@@ -197,7 +197,7 @@ func (b *backend) pathSetManageCheckIn() *framework.Path {
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.ReadOperation: &framework.PathOperation{
+			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.operationCheckIn(true),
 				Summary:  "Check service accounts in to the library.",
 			},

--- a/plugin/path_checkouts_test.go
+++ b/plugin/path_checkouts_test.go
@@ -1,0 +1,34 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func TestCanCheckIn(t *testing.T) {
+	can := canCheckIn(&logical.Request{}, &CheckOut{}, true)
+	if !can {
+		t.Fatal("failing because check-in enforcement should be overridden")
+	}
+	can = canCheckIn(&logical.Request{EntityID: "foo"}, &CheckOut{BorrowerEntityID: "foo"}, false)
+	if !can {
+		t.Fatal("the entity that checked out the secret should be able to check it in")
+	}
+	can = canCheckIn(&logical.Request{ClientToken: "foo"}, &CheckOut{BorrowerClientToken: "foo"}, false)
+	if !can {
+		t.Fatal("the client token that checked out the secret should be able to check it in")
+	}
+	can = canCheckIn(&logical.Request{EntityID: "fizz"}, &CheckOut{BorrowerEntityID: "buzz"}, false)
+	if can {
+		t.Fatal("other entities shouldn't be able to perform check-ins")
+	}
+	can = canCheckIn(&logical.Request{ClientToken: "fizz"}, &CheckOut{BorrowerClientToken: "buzz"}, false)
+	if can {
+		t.Fatal("other tokens shouldn't be able to perform check-ins")
+	}
+	can = canCheckIn(&logical.Request{}, &CheckOut{}, false)
+	if can {
+		t.Fatal("when insufficient auth info is provided, check-in should not be allowed")
+	}
+}

--- a/plugin/path_checkouts_test.go
+++ b/plugin/path_checkouts_test.go
@@ -6,28 +6,24 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func TestCanCheckIn(t *testing.T) {
-	can := canCheckIn(&logical.Request{}, &CheckOut{}, true)
-	if !can {
-		t.Fatal("failing because check-in enforcement should be overridden")
-	}
-	can = canCheckIn(&logical.Request{EntityID: "foo"}, &CheckOut{BorrowerEntityID: "foo"}, false)
+func TestCheckInAuthorized(t *testing.T) {
+	can := checkinAuthorized(&logical.Request{EntityID: "foo"}, &CheckOut{BorrowerEntityID: "foo"})
 	if !can {
 		t.Fatal("the entity that checked out the secret should be able to check it in")
 	}
-	can = canCheckIn(&logical.Request{ClientToken: "foo"}, &CheckOut{BorrowerClientToken: "foo"}, false)
+	can = checkinAuthorized(&logical.Request{ClientToken: "foo"}, &CheckOut{BorrowerClientToken: "foo"})
 	if !can {
 		t.Fatal("the client token that checked out the secret should be able to check it in")
 	}
-	can = canCheckIn(&logical.Request{EntityID: "fizz"}, &CheckOut{BorrowerEntityID: "buzz"}, false)
+	can = checkinAuthorized(&logical.Request{EntityID: "fizz"}, &CheckOut{BorrowerEntityID: "buzz"})
 	if can {
 		t.Fatal("other entities shouldn't be able to perform check-ins")
 	}
-	can = canCheckIn(&logical.Request{ClientToken: "fizz"}, &CheckOut{BorrowerClientToken: "buzz"}, false)
+	can = checkinAuthorized(&logical.Request{ClientToken: "fizz"}, &CheckOut{BorrowerClientToken: "buzz"})
 	if can {
 		t.Fatal("other tokens shouldn't be able to perform check-ins")
 	}
-	can = canCheckIn(&logical.Request{}, &CheckOut{}, false)
+	can = checkinAuthorized(&logical.Request{}, &CheckOut{})
 	if can {
 		t.Fatal("when insufficient auth info is provided, check-in should not be allowed")
 	}


### PR DESCRIPTION
These endpoints are all PR'd together because they play into each other. How check-outs are done effects how check-ins, renewals, and revocations are done, and vice-versa. _Originally, race detection was not included in this PR due to size, but it was requested as part of the review so has been added._

This code has been tested at the CLI against a real AD server. All sunny paths work, including using the leasing system for checkout renewals and revocations (both manual revocations and ones due to a check-out expiring). TTL and maxTTL behavior has been tested and behaves as expected. 

This feature basically _looks_ complete from the outside now, though there's still more to do to make it prod-ready.

Still TODO (separately):
- Flatten the `CheckOutHandler` object model (#54, which will need to be reviewed after this is merged because merge conflicts due to this PR will need to be resolved) 
- Additional bug bash and UX testing (planned for our testing cycle when the beta is out)