### PR TITLE
Improve unavailable response and CLI help

### DIFF
--- a/plugin/path_checkout_sets.go
+++ b/plugin/path_checkout_sets.go
@@ -360,14 +360,14 @@ func storeSet(ctx context.Context, storage logical.Storage, setName string, set 
 
 const (
 	setHelpSynopsis = `
-Manage sets to build a library of service accounts that can be checked out.
+Build a library of service accounts that can be checked out.
 `
 	setHelpDescription = `
-This endpoint allows you to read, write, and delete individual sets that are used for checking out service accounts.
-Deleting a set can only be performed if all of its service accounts are currently checked in.
+This endpoint allows you to read, write, and delete individual sets of service accounts for check-out.
+Deleting a set of service accounts can only be performed if all its accounts are currently checked in.
 `
 	pathListSetsHelpSyn = `
-List the name of each set currently stored.
+List the name of each set of service accounts currently stored.
 `
 	pathListSetsHelpDesc = `
 To learn which service accounts are being managed by Vault, list the set names using

--- a/plugin/path_checkouts.go
+++ b/plugin/path_checkouts.go
@@ -107,10 +107,7 @@ func (b *backend) operationSetCheckOut(ctx context.Context, req *logical.Request
 	// In case of customer issues, we need to make this easy to see and diagnose.
 	b.Logger().Debug(fmt.Sprintf(`%q had no check-outs available`, setName))
 	metrics.IncrCounter([]string{"active directory", "check-out", "unavailable", setName}, 1)
-
-	return logical.RespondWithStatusCode(&logical.Response{
-		Warnings: []string{"No service accounts available for check-out."},
-	}, req, 400)
+	return logical.ErrorResponse("No service accounts available for check-out."), nil
 }
 
 func (b *backend) secretAccessKeys() *framework.Secret {


### PR DESCRIPTION
When checkouts were unavailable, Vault was returning:
```
$ vault write -f ad/library/accounting-team/check-out
Error writing data to ad/library/accounting-team/check-out: Error making API request.

URL: PUT http://localhost:8200/v1/ad/library/accounting-team/check-out
Code: 400. Errors:
```

This improves that to be more explicit:
```
$ vault write -f ad/library/accounting-team/check-out
Error writing data to ad/library/accounting-team/check-out: Error making API request.

URL: PUT http://localhost:8200/v1/ad/library/accounting-team/check-out
Code: 400. Errors:

* No service accounts available for check-out.
```

Also includes a couple of CLI wordsmiths.