### PR TITLE
Allow binddn in separate tree

### DIFF
--- a/plugin/client/client.go
+++ b/plugin/client/client.go
@@ -26,7 +26,6 @@ type Client struct {
 	ldap *ldaputil.Client
 }
 
-// TODO this used to always be the cfg.UserDN.
 func (c *Client) Search(cfg *ADConf, baseDN string, filters map[*Field][]string) ([]*Entry, error) {
 	req := &ldap.SearchRequest{
 		BaseDN:    baseDN,

--- a/plugin/client/client.go
+++ b/plugin/client/client.go
@@ -26,9 +26,10 @@ type Client struct {
 	ldap *ldaputil.Client
 }
 
-func (c *Client) Search(cfg *ADConf, filters map[*Field][]string) ([]*Entry, error) {
+// TODO this used to always be the cfg.UserDN.
+func (c *Client) Search(cfg *ADConf, baseDN string, filters map[*Field][]string) ([]*Entry, error) {
 	req := &ldap.SearchRequest{
-		BaseDN:    cfg.UserDN,
+		BaseDN:    baseDN,
 		Scope:     ldap.ScopeWholeSubtree,
 		Filter:    toString(filters),
 		SizeLimit: math.MaxInt32,
@@ -56,8 +57,8 @@ func (c *Client) Search(cfg *ADConf, filters map[*Field][]string) ([]*Entry, err
 	return entries, nil
 }
 
-func (c *Client) UpdateEntry(cfg *ADConf, filters map[*Field][]string, newValues map[*Field][]string) error {
-	entries, err := c.Search(cfg, filters)
+func (c *Client) UpdateEntry(cfg *ADConf, baseDN string, filters map[*Field][]string, newValues map[*Field][]string) error {
+	entries, err := c.Search(cfg, baseDN, filters)
 	if err != nil {
 		return err
 	}
@@ -89,7 +90,7 @@ func (c *Client) UpdateEntry(cfg *ADConf, filters map[*Field][]string, newValues
 // Active Directory doesn't recognize the passwordModify method.
 // See https://github.com/go-ldap/ldap/issues/106
 // for more.
-func (c *Client) UpdatePassword(cfg *ADConf, filters map[*Field][]string, newPassword string) error {
+func (c *Client) UpdatePassword(cfg *ADConf, baseDN string, filters map[*Field][]string, newPassword string) error {
 	pwdEncoded, err := formatPassword(newPassword)
 	if err != nil {
 		return err
@@ -99,7 +100,7 @@ func (c *Client) UpdatePassword(cfg *ADConf, filters map[*Field][]string, newPas
 		FieldRegistry.UnicodePassword: {pwdEncoded},
 	}
 
-	return c.UpdateEntry(cfg, filters, newValues)
+	return c.UpdateEntry(cfg, baseDN, filters, newValues)
 }
 
 // According to the MS docs, the password needs to be utf16 and enclosed in quotes.

--- a/plugin/client/client_test.go
+++ b/plugin/client/client_test.go
@@ -28,7 +28,7 @@ func TestSearch(t *testing.T) {
 		FieldRegistry.Surname: {"Jones"},
 	}
 
-	entries, err := client.Search(config, filters)
+	entries, err := client.Search(config, config.UserDN, filters)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestUpdateEntry(t *testing.T) {
 		FieldRegistry.CommonName: {"Blue", "Red"},
 	}
 
-	if err := client.UpdateEntry(config, filters, newValues); err != nil {
+	if err := client.UpdateEntry(config, config.UserDN, filters, newValues); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -132,7 +132,7 @@ func TestUpdatePassword(t *testing.T) {
 		FieldRegistry.Surname: {"Jones"},
 	}
 
-	if err := client.UpdatePassword(config, filters, testPass); err != nil {
+	if err := client.UpdatePassword(config, config.UserDN, filters, testPass); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/plugin/client/tools/simplecall.go
+++ b/plugin/client/tools/simplecall.go
@@ -28,7 +28,7 @@ func main() {
 		client.FieldRegistry.GivenName: {"Sara", "Sarah"},
 	}
 
-	entries, err := c.Search(config, filters)
+	entries, err := c.Search(config, config.UserDN, filters)
 	if err != nil {
 		fmt.Println(err.Error())
 		return

--- a/plugin/util/secrets_client.go
+++ b/plugin/util/secrets_client.go
@@ -22,7 +22,7 @@ func (c *SecretsClient) Get(conf *client.ADConf, serviceAccountName string) (*cl
 		client.FieldRegistry.UserPrincipalName: {serviceAccountName},
 	}
 
-	entries, err := c.adClient.Search(conf, filters)
+	entries, err := c.adClient.Search(conf, conf.UserDN, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -68,12 +68,12 @@ func (c *SecretsClient) UpdatePassword(conf *client.ADConf, serviceAccountName s
 	filters := map[*client.Field][]string{
 		client.FieldRegistry.UserPrincipalName: {serviceAccountName},
 	}
-	return c.adClient.UpdatePassword(conf, filters, newPassword)
+	return c.adClient.UpdatePassword(conf, conf.UserDN, filters, newPassword)
 }
 
 func (c *SecretsClient) UpdateRootPassword(conf *client.ADConf, bindDN string, newPassword string) error {
 	filters := map[*client.Field][]string{
 		client.FieldRegistry.DistinguishedName: {bindDN},
 	}
-	return c.adClient.UpdatePassword(conf, filters, newPassword)
+	return c.adClient.UpdatePassword(conf, conf.BindDN, filters, newPassword)
 }

--- a/plugin/util/secrets_client.go
+++ b/plugin/util/secrets_client.go
@@ -75,5 +75,11 @@ func (c *SecretsClient) UpdateRootPassword(conf *client.ADConf, bindDN string, n
 	filters := map[*client.Field][]string{
 		client.FieldRegistry.DistinguishedName: {bindDN},
 	}
+	// Here, use the binddn as the base for the search tree, since it actually may live
+	// in a separate location from the users it's managing. For example, suppose the root
+	// user was in a "Security" OU, while the users whose passwords were being managed were
+	// in a separate, non-overlapping "Accounting" OU. We wouldn't want to search the
+	// accounting team to rotate the security user's password, we'd want to search the
+	// security team.
 	return c.adClient.UpdatePassword(conf, conf.BindDN, filters, newPassword)
 }


### PR DESCRIPTION
This PR addresses an issue where a user's `binddn` (which is used as the "root" account) was located in a separate tree from their `userdn`. More specifically, their `binddn` was from the Security organizational unit, and their `userdn` was from a separate, non-overlapping organizational unit. Since the code previously looked for the root account under the `userdn`, it wasn't finding the root account and couldn't rotate its credentials.

One solution would be for the user to set a `userdn` that encompassed them both, but it would have made searches take too long for their company.

This PR really only changes one thing - when `"ad/rotate-root"` is called to rotate root credentials, the _binddn_ is now used to search for it, allowing it to live happily in a separate tree. This will _always_ have a successful hit, no matter where it lives in relation to the users whose passwords are being rotated by it.

**How this was tested**

In addition to the tests below, this PR was tested against a live Active Directory server to ensure its backwards and forwards compatibility.

For backwards compatibility a test was performed where the root account and the users all lived in the same OU on Active Directory. Then I tested whether both the user account passwords and the root password could be rotated. This succeeded with this configuration:

```
vault write ad/config \
    binddn='CN=vault-ad-test,CN=Users,DC=example,DC=com' \
    bindpass=$PASSWORD \
    url=ldaps://$PUBLIC_IP_ADDR \
    userdn='dc=example,dc=com' \
    insecure_tls=true
```

To check that this PR solves the stated problem, I also created a Security OU and moved the root account into it, and then I created a separate and non-overlapping Accounting OU and moved the user accounts into it. Then I tested whether both the user account passwords and the root password could be rotated. This succeeded with this configuration:

```
vault write ad/config \
    binddn='CN=vault-ad-test,OU=Security,DC=example,DC=com' \
    bindpass=$PASSWORD \
    url=ldaps://$PUBLIC_IP_ADDR \
    userdn='OU=Accounting,DC=example,DC=com' \
    insecure_tls=true
```
I used `ldapsearch` to ensure that the `binddn` and `userdn` I used were correctly targeting the intended entities.