### PR TITLE
Auto disable account feature for checkin - checkout

### DIFF
--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -92,6 +92,8 @@ type secretsClient interface {
 	GetPasswordLastSet(conf *client.ADConf, serviceAccountName string) (time.Time, error)
 	UpdatePassword(conf *client.ADConf, serviceAccountName string, newPassword string) error
 	UpdateRootPassword(conf *client.ADConf, bindDN string, newPassword string) error
+	EnableAccount(conf *client.ADConf, serviceAccountName string) error
+	DisableAccount(conf *client.ADConf, serviceAccountName string) error
 }
 
 const backendHelp = `

--- a/plugin/client/uac_bits.go
+++ b/plugin/client/uac_bits.go
@@ -1,0 +1,47 @@
+package client
+
+// Bits type
+type Bits uint32
+
+// Has the given flag this flag
+func (f Bits) Has(flag Bits) bool { return f&flag != 0 }
+
+// Add flag to the existing one
+func (f *Bits) Add(flag Bits) { *f |= flag }
+
+// Clear flag. The flag is removed
+func (f *Bits) Clear(flag Bits) { *f &= ^flag }
+
+// Toggle flag
+func (f *Bits) Toggle(flag Bits) { *f ^= flag }
+
+// UserAccountControl constants from https://support.microsoft.com/en-us/help/305144/how-to-use-useraccountcontrol-to-manipulate-user-account-properties
+const (
+	SCRIPT                         = 1 << iota // 1
+	ACCOUNTDISABLE                             // 2
+	_                                          // skip
+	HOMEDIR_REQUIRED                           // 8
+	LOCKOUT                                    // 16
+	PASSWD_NOTREQD                             // 32
+	PASSWD_CANT_CHANGE                         // 64
+	ENCRYPTED_TEXT_PWD_ALLOWED                 // 128
+	TEMP_DUPLICATE_ACCOUNT                     // 256
+	NORMAL_ACCOUNT                             // 512
+	_                                          // skip
+	INTERDOMAIN_TRUST_ACCOUNT                  // 2048
+	WORKSTATION_TRUST_ACCOUNT                  // 4096
+	SERVER_TRUST_ACCOUNT                       // 8192
+	_                                          // skip
+	_                                          // skip
+	DONT_EXPIRE_PASSWORD                       // 65536
+	MNS_LOGON_ACCOUNT                          // 131072
+	SMARTCARD_REQUIRED                         // 262144
+	TRUSTED_FOR_DELEGATION                     // 524288
+	NOT_DELEGATED                              // 1048576
+	USE_DES_KEY_ONLY                           // 2097152
+	DONT_REQ_PREAUTH                           // 4194304
+	PASSWORD_EXPIRED                           // 8388608
+	TRUSTED_TO_AUTH_FOR_DELEGATION             // 16777216
+	_                                          // skip
+	PARTIAL_SECRETS_ACCOUNT                    // 67108864
+)

--- a/plugin/client/uac_bits_test.go
+++ b/plugin/client/uac_bits_test.go
@@ -1,0 +1,94 @@
+package client
+
+import "testing"
+
+func TestBits_Has(t *testing.T) {
+	tests := []struct {
+		name string
+		f    Bits
+		val  Bits
+		want bool
+	}{
+		{"Has only one Bit", Bits(512), NORMAL_ACCOUNT, true},
+		{"Has one Bit among a few", Bits(514), NORMAL_ACCOUNT, true},
+		{"Has one Bit among a few", Bits(514), ACCOUNTDISABLE, true},
+		{"Has not a Bit among a few", Bits(514), LOCKOUT, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.f.Has(tt.val); got != tt.want {
+				t.Errorf("Bits.Has() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBits_Add(t *testing.T) {
+	result := Bits(0)
+	tests := []struct {
+		name string
+		f    *Bits
+		val  Bits
+		want Bits
+	}{
+		{"Add a NORMAL_ACCOUNT flag", &result, NORMAL_ACCOUNT, Bits(0x200)},
+		{"Add a ACCOUNT_DISABLE flag", &result, ACCOUNTDISABLE, Bits(0x202)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.f.Add(tt.val)
+			if *tt.f != tt.want {
+				t.Errorf("Bits.Add(%x) = %x, want %x", tt.val, *tt.f, tt.want)
+			}
+		})
+	}
+}
+
+func TestBits_Clear(t *testing.T) {
+	result := Bits(0)
+	result.Add(NORMAL_ACCOUNT)
+	result.Add(ACCOUNTDISABLE)
+	result.Add(DONT_EXPIRE_PASSWORD)
+	tests := []struct {
+		name string
+		f    *Bits
+		val  Bits
+		want Bits
+	}{
+		{"Clear a DONT_EXPIRE_PASSWORD flag", &result, DONT_EXPIRE_PASSWORD, Bits(0x202)},
+		{"Clear a unknown flag (HOMEDIR_REQUIRED) flag", &result, HOMEDIR_REQUIRED, Bits(0x202)},
+		{"Add a NORMAL_ACCOUNT flag", &result, NORMAL_ACCOUNT, Bits(0x2)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.f.Clear(tt.val)
+			if *tt.f != tt.want {
+				t.Errorf("Bits.Clear(%x) = %x, want %x", tt.val, *tt.f, tt.want)
+			}
+		})
+	}
+}
+
+func TestBits_Toggle(t *testing.T) {
+	result := Bits(0)
+	result.Add(NORMAL_ACCOUNT)
+	result.Add(ACCOUNTDISABLE)
+	tests := []struct {
+		name string
+		f    *Bits
+		val  Bits
+		want Bits
+	}{
+		{"Xor with NORMAL_ACCOUNT flag", &result, NORMAL_ACCOUNT, Bits(0x2)},
+		{"Xor with HOMEDIR_REQUIRED flag", &result, HOMEDIR_REQUIRED, Bits(0xa)},
+		{"Xor with ACCOUNTDISABLE flag", &result, ACCOUNTDISABLE, Bits(0x8)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.f.Toggle(tt.val)
+			if *tt.f != tt.want {
+				t.Errorf("Bits.Toggle(%x) = %x, want %x", tt.val, *tt.f, tt.want)
+			}
+		})
+	}
+}

--- a/plugin/path_creds_test.go
+++ b/plugin/path_creds_test.go
@@ -116,3 +116,11 @@ func (f *thisFake) UpdatePassword(conf *client.ADConf, serviceAccountName string
 func (f *thisFake) UpdateRootPassword(conf *client.ADConf, bindDN string, newPassword string) error {
 	return nil
 }
+
+func (f *thisFake) EnableAccount(conf *client.ADConf, serviceAccountName string) error {
+	return nil
+}
+
+func (f *thisFake) DisableAccount(conf *client.ADConf, serviceAccountName string) error {
+	return nil
+}

--- a/plugin/path_rotate_root_creds_test.go
+++ b/plugin/path_rotate_root_creds_test.go
@@ -1,11 +1,12 @@
 package plugin
 
 import (
+	"testing"
+	"time"
+
 	"github.com/go-errors/errors"
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
 	"github.com/hashicorp/vault/sdk/helper/ldaputil"
-	"testing"
-	"time"
 )
 
 func TestRollBackPassword(t *testing.T) {
@@ -89,5 +90,13 @@ func (f *badFake) UpdatePassword(conf *client.ADConf, serviceAccountName string,
 }
 
 func (f *badFake) UpdateRootPassword(conf *client.ADConf, bindDN string, newPassword string) error {
+	return errors.New("nope")
+}
+
+func (f *badFake) EnableAccount(conf *client.ADConf, serviceAccountName string) error {
+	return errors.New("nope")
+}
+
+func (f *badFake) DisableAccount(conf *client.ADConf, serviceAccountName string) error {
 	return errors.New("nope")
 }


### PR DESCRIPTION
# Overview
Who the change affects or is for (stakeholders)? All the users that activate the feature on library management
What is the change? Give the possibility to lock (disable) the service account on check-in and to unlock it (enable) on check-out
Why is the change needed? Provide a additional level of security on service accounts
How does this change affect the user experience (if at all)? Ensure that an account that is check-in cannot be used.

# Design of Change
How was this change implemented? 
  - Provide the functions to manage the UserAccountControl attribute by adding ou removing the ACCOUNT_DISABLE flag.
  - Add the auto_disable_account (boolean) parameter on the set configuration
  - Update the check-in / check-out method

# Related Issues/Pull Requests
No issue, just an identified need

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests) : tests 
[ ] Backwards compatible
