### PR TITLE
Add support for POST/write to rotate root credentials

### DIFF
--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -52,6 +52,7 @@ func TestBackend(t *testing.T) {
 
 	// Exercise root credential rotation.
 	t.Run("rotate root creds", RotateRootCreds)
+	t.Run("rotate root creds", RotateRootCredsWithPost)
 }
 
 func WriteConfig(t *testing.T) {
@@ -287,6 +288,21 @@ func ReadCred(t *testing.T) {
 func RotateRootCreds(t *testing.T) {
 	req := &logical.Request{
 		Operation: logical.ReadOperation,
+		Path:      "rotate-root",
+		Storage:   testStorage,
+	}
+	resp, err := testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp != nil {
+		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+	}
+}
+
+func RotateRootCredsWithPost(t *testing.T) {
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
 		Path:      "rotate-root",
 		Storage:   testStorage,
 	}

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -52,7 +52,7 @@ func TestBackend(t *testing.T) {
 
 	// Exercise root credential rotation.
 	t.Run("rotate root creds", RotateRootCreds)
-	t.Run("rotate root creds", RotateRootCredsWithPost)
+	t.Run("rotate root creds with write", RotateRootCredsWithPost)
 }
 
 func WriteConfig(t *testing.T) {

--- a/plugin/path_rotate_root_creds.go
+++ b/plugin/path_rotate_root_creds.go
@@ -16,7 +16,17 @@ func (b *backend) pathRotateCredentials() *framework.Path {
 	return &framework.Path{
 		Pattern: "rotate-root",
 		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback:                    b.pathRotateCredentialsUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
+			},
 			logical.ReadOperation: &framework.PathOperation{
+				Callback:                    b.pathRotateCredentialsUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
 				Callback:                    b.pathRotateCredentialsUpdate,
 				ForwardPerformanceStandby:   true,
 				ForwardPerformanceSecondary: true,

--- a/plugin/path_rotate_root_creds_test.go
+++ b/plugin/path_rotate_root_creds_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+// Tests to check root credential rotation are found in ./backend_test.go
+
 func TestRollBackPassword(t *testing.T) {
 	if testing.Short() {
 		t.Skip()


### PR DESCRIPTION
# Overview
This looks to add support for a `vault write` or `POST` operation to rotate root credentials. This brings the overall user experience in line with the rest of the secrets plugins vault provides.

This change will not impact the existing `vault read` and `GET` operations, leaving existing workflows intact.

# Design of Change
Support for routing to an `UpdateOperation` was added to the existing `ReadOperation`

# Contributor Checklist
[x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](https://github.com/hashicorp/vault/pull/9990)
[x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible

# Test Output
```
/usr/local/go/bin/go test -json ./...
=== RUN   TestSearch
--- PASS: TestSearch (0.00s)
=== RUN   TestUpdateEntry
--- PASS: TestUpdateEntry (0.00s)
=== RUN   TestUpdatePassword
--- PASS: TestUpdatePassword (0.00s)
=== RUN   TestUpdateRootPassword
--- PASS: TestUpdateRootPassword (0.00s)
=== RUN   TestIfEntryCreationIsRacy
--- PASS: TestIfEntryCreationIsRacy (1.01s)
=== RUN   TestFieldRegistryListsFields
--- PASS: TestFieldRegistryListsFields (0.00s)
=== RUN   TestFieldRegistryEqualityComparisonsWork
--- PASS: TestFieldRegistryEqualityComparisonsWork (0.00s)
=== RUN   TestFieldRegistryParsesFieldsByString
--- PASS: TestFieldRegistryParsesFieldsByString (0.00s)
=== RUN   TestParseTime
--- PASS: TestParseTime (0.00s)
PASS
ok  	github.com/hashicorp/vault-plugin-secrets-ad/plugin/client	(cached)
=== RUN   TestCheckOuts
--- PASS: TestCheckOuts (0.00s)
=== RUN   TestCheckOuts/plant_config
    --- PASS: TestCheckOuts/plant_config (0.00s)
=== RUN   TestCheckOuts/write_set
    --- PASS: TestCheckOuts/write_set (0.00s)
=== RUN   TestCheckOuts/read_set
    --- PASS: TestCheckOuts/read_set (0.00s)
=== RUN   TestCheckOuts/read_set_status
    --- PASS: TestCheckOuts/read_set_status (0.00s)
=== RUN   TestCheckOuts/write_set_toggle_off
    --- PASS: TestCheckOuts/write_set_toggle_off (0.00s)
=== RUN   TestCheckOuts/read_set_toggle_off
    --- PASS: TestCheckOuts/read_set_toggle_off (0.00s)
=== RUN   TestCheckOuts/write_conflicting_set
    --- PASS: TestCheckOuts/write_conflicting_set (0.00s)
=== RUN   TestCheckOuts/list_sets
    --- PASS: TestCheckOuts/list_sets (0.00s)
=== RUN   TestCheckOuts/delete_set
    --- PASS: TestCheckOuts/delete_set (0.00s)
=== RUN   TestCheckOuts/write_set#01
    --- PASS: TestCheckOuts/write_set#01 (0.00s)
=== RUN   TestCheckOuts/add_service_account
    --- PASS: TestCheckOuts/add_service_account (0.00s)
=== RUN   TestCheckOuts/remove_service_account
    --- PASS: TestCheckOuts/remove_service_account (0.00s)
=== RUN   TestCheckOuts/check_initial_status
    --- PASS: TestCheckOuts/check_initial_status (0.00s)
=== RUN   TestCheckOuts/check_out_account
    --- PASS: TestCheckOuts/check_out_account (0.00s)
=== RUN   TestCheckOuts/check_updated_status
    --- PASS: TestCheckOuts/check_updated_status (0.00s)
=== RUN   TestCheckOuts/normal_check_in
    --- PASS: TestCheckOuts/normal_check_in (0.00s)
=== RUN   TestCheckOuts/return_to_initial_status
    --- PASS: TestCheckOuts/return_to_initial_status (0.00s)
=== RUN   TestCheckOuts/check_out_again
    --- PASS: TestCheckOuts/check_out_again (0.00s)
=== RUN   TestCheckOuts/check_updated_status#01
    --- PASS: TestCheckOuts/check_updated_status#01 (0.00s)
=== RUN   TestCheckOuts/force_check_in
    --- PASS: TestCheckOuts/force_check_in (0.00s)
=== RUN   TestCheckOuts/check_all_are_available
    --- PASS: TestCheckOuts/check_all_are_available (0.00s)
=== RUN   TestCheckOutRaces
--- PASS: TestCheckOutRaces (0.01s)
=== RUN   TestBackend
--- PASS: TestBackend (0.00s)
=== RUN   TestBackend/write_config
    --- PASS: TestBackend/write_config (0.00s)
=== RUN   TestBackend/read_config
    --- PASS: TestBackend/read_config (0.00s)
=== RUN   TestBackend/delete_config
    --- PASS: TestBackend/delete_config (0.00s)
=== RUN   TestBackend/plant_config
    --- PASS: TestBackend/plant_config (0.00s)
=== RUN   TestBackend/write_role
    --- PASS: TestBackend/write_role (0.00s)
=== RUN   TestBackend/read_role
    --- PASS: TestBackend/read_role (0.00s)
=== RUN   TestBackend/list_roles
    --- PASS: TestBackend/list_roles (0.00s)
=== RUN   TestBackend/delete_role
    --- PASS: TestBackend/delete_role (0.00s)
=== RUN   TestBackend/plant_role
    --- PASS: TestBackend/plant_role (0.00s)
=== RUN   TestBackend/read_cred
    --- PASS: TestBackend/read_cred (0.00s)
=== RUN   TestBackend/rotate_root_creds
    --- PASS: TestBackend/rotate_root_creds (0.00s)
=== RUN   TestBackend/rotate_root_creds#01
    --- PASS: TestBackend/rotate_root_creds#01 (0.00s)
=== RUN   TestCheckOutHandlerStorageLayer
--- PASS: TestCheckOutHandlerStorageLayer (0.00s)
=== RUN   TestPasswordHandlerInterfaceFulfillment
--- PASS: TestPasswordHandlerInterfaceFulfillment (0.00s)
=== RUN   TestCanUnmarshalPreviousConfig
--- PASS: TestCanUnmarshalPreviousConfig (0.00s)
=== RUN   TestCanUnmarshalNewConfig
--- PASS: TestCanUnmarshalNewConfig (0.00s)
=== RUN   TestValidatePasswordConf
--- PASS: TestValidatePasswordConf (0.00s)
=== RUN   TestValidatePasswordConf/has_policy_name_and_formatter
    --- PASS: TestValidatePasswordConf/has_policy_name_and_formatter (0.00s)
=== RUN   TestValidatePasswordConf/has_policy_name_and_length_and_formatter
    --- PASS: TestValidatePasswordConf/has_policy_name_and_length_and_formatter (0.00s)
=== RUN   TestValidatePasswordConf/has_formatter,_too_many_PASSWORD_fields
    --- PASS: TestValidatePasswordConf/has_formatter,_too_many_PASSWORD_fields (0.00s)
=== RUN   TestValidatePasswordConf/no_formatter,_long_length
    --- PASS: TestValidatePasswordConf/no_formatter,_long_length (0.00s)
=== RUN   TestValidatePasswordConf/has_formatter,_long_length
    --- PASS: TestValidatePasswordConf/has_formatter,_long_length (0.00s)
=== RUN   TestValidatePasswordConf/has_formatter,_short_length
    --- PASS: TestValidatePasswordConf/has_formatter,_short_length (0.00s)
=== RUN   TestValidatePasswordConf/default_config_errors
    --- PASS: TestValidatePasswordConf/default_config_errors (0.00s)
=== RUN   TestValidatePasswordConf/has_policy
    --- PASS: TestValidatePasswordConf/has_policy (0.00s)
=== RUN   TestValidatePasswordConf/has_policy_name_and_length
    --- PASS: TestValidatePasswordConf/has_policy_name_and_length (0.00s)
=== RUN   TestValidatePasswordConf/has_formatter,_missing_PASSWORD_field
    --- PASS: TestValidatePasswordConf/has_formatter,_missing_PASSWORD_field (0.00s)
=== RUN   TestValidatePasswordConf/no_formatter,_too_short
    --- PASS: TestValidatePasswordConf/no_formatter,_too_short (0.00s)
=== RUN   TestGeneratePassword
--- PASS: TestGeneratePassword (0.00s)
=== RUN   TestGeneratePassword/deprecated_with_formatter_prefix
    --- PASS: TestGeneratePassword/deprecated_with_formatter_prefix (0.00s)
=== RUN   TestGeneratePassword/deprecated_with_formatter_suffix
    --- PASS: TestGeneratePassword/deprecated_with_formatter_suffix (0.00s)
=== RUN   TestGeneratePassword/deprecated_with_formatter_prefix_and_suffix
    --- PASS: TestGeneratePassword/deprecated_with_formatter_prefix_and_suffix (0.00s)
=== RUN   TestGeneratePassword/missing_configs
    --- PASS: TestGeneratePassword/missing_configs (0.00s)
=== RUN   TestGeneratePassword/policy_failure
    --- PASS: TestGeneratePassword/policy_failure (0.00s)
=== RUN   TestGeneratePassword/successful_policy
    --- PASS: TestGeneratePassword/successful_policy (0.00s)
=== RUN   TestGeneratePassword/deprecated_with_no_formatter
    --- PASS: TestGeneratePassword/deprecated_with_no_formatter (0.00s)
=== RUN   TestCheckInAuthorized
--- PASS: TestCheckInAuthorized (0.00s)
=== RUN   TestCacheReader
--- PASS: TestCacheReader (0.00s)
=== RUN   Test_TTLIsRespected
2020-09-21T10:30:27.364-0700 [DEBUG] role is: &{ServiceAccountName:vault_test2@aaa.bbb.ccc.com TTL:7776000 LastVaultRotation:0001-01-01 00:00:00 +0000 UTC PasswordLastSet:2019-04-17 23:10:58 +0000 UTC}
2020-09-21T10:30:27.364-0700 [INFO]  rotating password for the first time so Vault will know it
2020-09-21T10:30:27.364-0700 [DEBUG] role is: &{ServiceAccountName:vault_test2@aaa.bbb.ccc.com TTL:7776000 LastVaultRotation:2020-09-21 17:30:27.364621 +0000 UTC PasswordLastSet:2019-04-17 23:10:58 +0000 UTC}
2020-09-21T10:30:27.364-0700 [DEBUG] determining whether to rotate credential
2020-09-21T10:30:27.364-0700 [DEBUG] checking cached credential
2020-09-21T10:30:27.364-0700 [DEBUG] returning previous credential
--- PASS: Test_TTLIsRespected (0.00s)
=== RUN   TestRollBackPassword
--- PASS: TestRollBackPassword (30.00s)
=== RUN   TestOnlyDefaultTTLs
--- PASS: TestOnlyDefaultTTLs (0.00s)
=== RUN   TestCustomOperatorTTLButDefaultRoleTTL
--- PASS: TestCustomOperatorTTLButDefaultRoleTTL (0.00s)
=== RUN   TestTTLTooHigh
--- PASS: TestTTLTooHigh (0.00s)
PASS
ok  	github.com/hashicorp/vault-plugin-secrets-ad/plugin	31.475s
?   	github.com/hashicorp/vault-plugin-secrets-ad/plugin/client/tools	[no test files]
?   	github.com/hashicorp/vault-plugin-secrets-ad/plugin/ldapifc	[no test files]
?   	github.com/hashicorp/vault-plugin-secrets-ad/plugin/util	[no test files]

Process finished with exit code 0
```