### PR TITLE
Ensure read config returns correct password policy key

### DIFF
--- a/plugin/config.go
+++ b/plugin/config.go
@@ -18,37 +18,37 @@ type passwordConf struct {
 	MaxTTL int `json:"max_ttl"`
 
 	// Mutually exclusive with Length and Formatter
-	PolicyName string `json:"password_policy"`
+	PasswordPolicy string `json:"password_policy"`
 
-	// Length of the password to generate. Mutually exclusive with PolicyName.
+	// Length of the password to generate. Mutually exclusive with PasswordPolicy.
 	// Deprecated
 	Length int `json:"length"`
 
 	// Formatter describes how to format a password. This allows for prefixes and suffixes on the password.
-	// Mutually exclusive with PolicyName.
+	// Mutually exclusive with PasswordPolicy.
 	// Deprecated
 	Formatter string `json:"formatter"`
 }
 
 func (c passwordConf) Map() map[string]interface{} {
 	return map[string]interface{}{
-		"ttl":         c.TTL,
-		"max_ttl":     c.MaxTTL,
-		"length":      c.Length,
-		"formatter":   c.Formatter,
-		"policy_name": c.PolicyName,
+		"ttl":             c.TTL,
+		"max_ttl":         c.MaxTTL,
+		"length":          c.Length,
+		"formatter":       c.Formatter,
+		"password_policy": c.PasswordPolicy,
 	}
 }
 
 // validate returns an error if the configuration is invalid/unable to process for whatever reason.
 func (c passwordConf) validate() error {
-	if c.PolicyName != "" &&
+	if c.PasswordPolicy != "" &&
 		(c.Length != 0 || c.Formatter != "") {
 		return fmt.Errorf("cannot set password_policy and either length or formatter")
 	}
 
-	// Don't validate the length and formatter fields if a policy is set
-	if c.PolicyName != "" {
+	// Don't PasswordPolicy the length and formatter fields if a policy is set
+	if c.PasswordPolicy != "" {
 		return nil
 	}
 

--- a/plugin/config_test.go
+++ b/plugin/config_test.go
@@ -101,29 +101,29 @@ func TestValidatePasswordConf(t *testing.T) {
 		},
 		"has policy": {
 			conf: passwordConf{
-				PolicyName: "testpolicy",
+				PasswordPolicy: "testpolicy",
 			},
 			expectErr: false,
 		},
 		"has policy name and length": {
 			conf: passwordConf{
-				PolicyName: "testpolicy",
-				Length:     20,
+				PasswordPolicy: "testpolicy",
+				Length:         20,
 			},
 			expectErr: true,
 		},
 		"has policy name and formatter": {
 			conf: passwordConf{
-				PolicyName: "testpolicy",
-				Formatter:  "foo{{PASSWORD}}",
+				PasswordPolicy: "testpolicy",
+				Formatter:      "foo{{PASSWORD}}",
 			},
 			expectErr: true,
 		},
 		"has policy name and length and formatter": {
 			conf: passwordConf{
-				PolicyName: "testpolicy",
-				Length:     20,
-				Formatter:  "foo{{PASSWORD}}",
+				PasswordPolicy: "testpolicy",
+				Length:         20,
+				Formatter:      "foo{{PASSWORD}}",
 			},
 			expectErr: true,
 		},

--- a/plugin/passwords.go
+++ b/plugin/passwords.go
@@ -16,7 +16,7 @@ var (
 )
 
 type passwordGenerator interface {
-	GeneratePasswordFromPolicy(ctx context.Context, PasswordPolicy string) (password string, err error)
+	GeneratePasswordFromPolicy(ctx context.Context, policyName string) (password string, err error)
 }
 
 // GeneratePassword from the password configuration. This will either generate based on a password policy

--- a/plugin/passwords.go
+++ b/plugin/passwords.go
@@ -16,7 +16,7 @@ var (
 )
 
 type passwordGenerator interface {
-	GeneratePasswordFromPolicy(ctx context.Context, policyName string) (password string, err error)
+	GeneratePasswordFromPolicy(ctx context.Context, PasswordPolicy string) (password string, err error)
 }
 
 // GeneratePassword from the password configuration. This will either generate based on a password policy
@@ -27,8 +27,8 @@ func GeneratePassword(ctx context.Context, passConf passwordConf, generator pass
 		return "", err
 	}
 
-	if passConf.PolicyName != "" {
-		return generator.GeneratePasswordFromPolicy(ctx, passConf.PolicyName)
+	if passConf.PasswordPolicy != "" {
+		return generator.GeneratePasswordFromPolicy(ctx, passConf.PasswordPolicy)
 	}
 	return generateDeprecatedPassword(passConf.Formatter, passConf.Length)
 }

--- a/plugin/passwords_test.go
+++ b/plugin/passwords_test.go
@@ -19,9 +19,9 @@ func TestGeneratePassword(t *testing.T) {
 	tests := map[string]testCase{
 		"missing configs": {
 			passConf: passwordConf{
-				Length:     0,
-				Formatter:  "",
-				PolicyName: "",
+				Length:         0,
+				Formatter:      "",
+				PasswordPolicy: "",
 			},
 			generator: nil,
 
@@ -30,7 +30,7 @@ func TestGeneratePassword(t *testing.T) {
 		},
 		"policy failure": {
 			passConf: passwordConf{
-				PolicyName: "testpolicy",
+				PasswordPolicy: "testpolicy",
 			},
 			generator:         makePasswordGenerator("", fmt.Errorf("test error")),
 			passwordAssertion: assertNoPassword,
@@ -38,7 +38,7 @@ func TestGeneratePassword(t *testing.T) {
 		},
 		"successful policy": {
 			passConf: passwordConf{
-				PolicyName: "testpolicy",
+				PasswordPolicy: "testpolicy",
 			},
 			generator:         makePasswordGenerator("testpassword", nil),
 			passwordAssertion: assertPassword("testpassword"),

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -143,11 +143,11 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 	}
 
 	passwordConf := passwordConf{
-		TTL:        ttl,
-		MaxTTL:     maxTTL,
-		Length:     length,
-		Formatter:  formatter,
-		PolicyName: passwordPolicy,
+		TTL:            ttl,
+		MaxTTL:         maxTTL,
+		Length:         length,
+		Formatter:      formatter,
+		PasswordPolicy: passwordPolicy,
 	}
 	err = passwordConf.validate()
 	if err != nil {


### PR DESCRIPTION
This PR addresses an inconsistency in `ad/config` where password policies are set using the key `password_policy` but are returned using a different key when `ad/config` is read:

``` bash
$ vault write ad/config \
      binddn=$USERNAME \
      bindpass=$PASSWORD \
      url=ldaps://138.91.247.105 \
      userdn='dc=example,dc=com' \
      password_policy='foobar' \
      formatter='' \
      length=0

$ vault read ad/config   
Key                             Value
---                             -----
binddn                          jasonodonnell
certificate                     n/a
formatter                       n/a
insecure_tls                    false
last_rotation_tolerance         5
length                          0
max_ttl                         768h
policy_name                     foobar
starttls                        false
tls_max_version                 tls12
tls_min_version                 tls12
ttl                             768h
upndomain                       n/a
url                             ldaps://138.91.247.105
use_pre111_group_cn_behavior    false
userdn                          dc=example,dc=com
```

I've also changed the name of the variables tracking this internally since the word `policy` is overloaded in Vault.