### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-    - image: circleci/golang:1.13.7
+    - image: docker.mirror.hashicorp.services/circleci/golang:1.13.7
     working_directory: /go/src/github.com/hashicorp/vault-plugin-secrets-ad
     steps:
     - checkout


### PR DESCRIPTION
# Overview
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. LMK if you have any q's, otherwise feel free to approve and merge on your own! 

# Contributor Checklist
This should have no external impact.
