### PR TITLE
Update Router To Forward Creds Requests

### DIFF
--- a/plugin/path_creds.go
+++ b/plugin/path_creds.go
@@ -47,8 +47,12 @@ func (b *backend) pathCreds() *framework.Path {
 				Description: "Name of the role",
 			},
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ReadOperation: b.credReadOperation,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback:                    b.credReadOperation,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
+			},
 		},
 		HelpSynopsis:    credHelpSynopsis,
 		HelpDescription: credHelpDescription,


### PR DESCRIPTION
AD secret engine does lazy password rotation when `creds` are accessed. To reduce multiple password rotations, these requests should be forwarded to the active Vault node.