### PR TITLE
Add rotate-role endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.5-0.20200215224050-f6547fa8e820
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200527182800-ad90e0b39d2f
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/mitchellh/mapstructure v1.2.2 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db
 	google.golang.org/protobuf v1.24.0 // indirect

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -40,6 +40,7 @@ func newBackend(client secretsClient, passwordGenerator passwordGenerator) *back
 			adBackend.pathRoles(),
 			adBackend.pathListRoles(),
 			adBackend.pathCreds(),
+			adBackend.pathRotateRootCredentials(),
 			adBackend.pathRotateCredentials(),
 
 			// The following paths are for AD credential checkout.
@@ -61,6 +62,8 @@ func newBackend(client secretsClient, passwordGenerator passwordGenerator) *back
 		Secrets: []*framework.Secret{
 			adBackend.secretAccessKeys(),
 		},
+		WALRollback:       adBackend.walRollback,
+		WALRollbackMinAge: 1 * time.Minute,
 	}
 	return adBackend
 }

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -50,6 +50,7 @@ func TestBackend(t *testing.T) {
 	// Exercise all cred endpoints.
 	t.Run("read cred", ReadCred)
 	t.Run("rotate role creds", RotateRolePassword)
+	t.Run("rollback role creds", RollbackRolePassword)
 
 	// Exercise root credential rotation.
 	t.Run("rotate root creds", RotateRootCreds)
@@ -373,6 +374,197 @@ func RotateRolePassword(t *testing.T) {
 	newPassword := resp.Data["current_password"].(string)
 	if password == newPassword {
 		t.Fatalf("Expected passwords to change when rotated role %s, but they did not", role)
+	}
+}
+
+func RollbackRolePassword(t *testing.T) {
+	role := "test_role_rollback"
+	// Create role
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      rolePrefix + role,
+		Storage:   testStorage,
+		Data: map[string]interface{}{
+			"service_account_name": "tester@example.com",
+			"ttl":                  10,
+		},
+	}
+	resp, err := testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+
+	if resp != nil {
+		t.Fatalf("expected no response, got %v", resp)
+	}
+
+	// Read role's creds
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      credPrefix + role,
+		Storage:   testStorage,
+	}
+	resp, err = testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	currentPassword := resp.Data["current_password"].(string)
+
+	// Read role for WAL building
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      rolePrefix + "test_role",
+		Storage:   testStorage,
+	}
+	resp, err = testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+
+	wal := map[string]interface{}{
+		"CurrentPassword":    currentPassword,
+		"LastPassword":       "",
+		"RoleName":           role,
+		"TTL":                resp.Data["ttl"].(int),
+		"ServiceAccountName": resp.Data["service_account_name"].(string),
+		"LastVaultRotation":  resp.Data["last_vault_rotation"],
+	}
+
+	// Rotate role's creds
+	req = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      rotateRolePath + role,
+		Storage:   testStorage,
+	}
+
+	resp, err = testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp != nil {
+		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+	}
+
+	// Rollback the creds
+	err = testBackend.handleRotateCredentialRollback(ctx, testStorage, wal)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read role's creds
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      credPrefix + role,
+		Storage:   testStorage,
+	}
+	resp, err = testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+
+	// Did we get the response data we expect?
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 items in %s but received %d", resp.Data, len(resp.Data))
+	}
+	if resp.Data["username"] != "tester" {
+		t.Fatalf("expected \"tester\" but received %q", resp.Data["username"])
+	}
+
+	newPassword := resp.Data["current_password"].(string)
+	if currentPassword != newPassword {
+		t.Fatalf("Expected passwords to be the same after rollback, they weren't: expected: %s:, got: %s", currentPassword, newPassword)
+	}
+}
+
+func DiscardWAL(t *testing.T) {
+	role := "test_role_discard"
+	// Create role
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      rolePrefix + role,
+		Storage:   testStorage,
+		Data: map[string]interface{}{
+			"service_account_name": "tester@example.com",
+			"ttl":                  10,
+		},
+	}
+	resp, err := testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+
+	if resp != nil {
+		t.Fatalf("expected no response, got %v", resp)
+	}
+
+	// Read role's creds
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      credPrefix + role,
+		Storage:   testStorage,
+	}
+	resp, err = testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	currentPassword := resp.Data["current_password"].(string)
+
+	// Read role for WAL building
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      rolePrefix + "test_role",
+		Storage:   testStorage,
+	}
+	resp, err = testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+
+	wal := map[string]interface{}{
+		"CurrentPassword":    currentPassword,
+		"LastPassword":       "",
+		"RoleName":           role,
+		"TTL":                resp.Data["ttl"].(int),
+		"ServiceAccountName": resp.Data["service_account_name"].(string),
+		"LastVaultRotation":  resp.Data["last_vault_rotation"],
+	}
+
+	resp, err = testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp != nil {
+		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+	}
+
+	// Rollback the creds
+	err = testBackend.handleRotateCredentialRollback(ctx, testStorage, wal)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read role's creds
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      credPrefix + role,
+		Storage:   testStorage,
+	}
+	resp, err = testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+
+	// Did we get the response data we expect?
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 items in %s but received %d", resp.Data, len(resp.Data))
+	}
+	if resp.Data["username"] != "tester" {
+		t.Fatalf("expected \"tester\" but received %q", resp.Data["username"])
+	}
+
+	newPassword := resp.Data["current_password"].(string)
+	if currentPassword != newPassword {
+		t.Fatalf("Expected passwords to be the same after rollback, they weren't: expected: %s:, got: %s", currentPassword, newPassword)
 	}
 }
 

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -51,6 +51,7 @@ func TestBackend(t *testing.T) {
 	t.Run("read cred", ReadCred)
 	t.Run("rotate role creds", RotateRolePassword)
 	t.Run("rollback role creds", RollbackRolePassword)
+	t.Run("discard WAL", DiscardWAL)
 
 	// Exercise root credential rotation.
 	t.Run("rotate root creds", RotateRootCreds)
@@ -527,14 +528,6 @@ func DiscardWAL(t *testing.T) {
 		"TTL":                resp.Data["ttl"].(int),
 		"ServiceAccountName": resp.Data["service_account_name"].(string),
 		"LastVaultRotation":  resp.Data["last_vault_rotation"],
-	}
-
-	resp, err = testBackend.HandleRequest(ctx, req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatal(err)
-	}
-	if resp != nil {
-		t.Fatal("expected no response because Vault generally doesn't return it for posts")
 	}
 
 	// Rollback the creds

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -49,6 +49,7 @@ func TestBackend(t *testing.T) {
 
 	// Exercise all cred endpoints.
 	t.Run("read cred", ReadCred)
+	t.Run("rotate role creds", RotateRolePassword)
 
 	// Exercise root credential rotation.
 	t.Run("rotate root creds", RotateRootCreds)
@@ -282,6 +283,96 @@ func ReadCred(t *testing.T) {
 	password := resp.Data["current_password"].(string)
 	if !strings.HasPrefix(password, passwordComplexityPrefix) {
 		t.Fatalf("%s doesn't have the expected complexity prefix of %s", password, passwordComplexityPrefix)
+	}
+}
+
+func RotateRolePassword(t *testing.T) {
+	role := "test_role"
+	// Create role
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      rolePrefix + role,
+		Storage:   testStorage,
+		Data: map[string]interface{}{
+			"service_account_name": "tester@example.com",
+			"ttl":                  10,
+		},
+	}
+	resp, err := testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+
+	if resp != nil {
+		t.Fatalf("expected no response, got %v", resp)
+	}
+
+	// Read role's creds
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      credPrefix + role,
+		Storage:   testStorage,
+	}
+	resp, err = testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+
+	// Did we get the response data we expect?
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 items in %s but received %d", resp.Data, len(resp.Data))
+	}
+	if resp.Data["username"] != "tester" {
+		t.Fatalf("expected \"tester\" but received %q", resp.Data["username"])
+	}
+
+	password := resp.Data["current_password"].(string)
+	if !strings.HasPrefix(password, passwordComplexityPrefix) {
+		t.Fatalf("%s doesn't have the expected complexity prefix of %s", password, passwordComplexityPrefix)
+	}
+
+	// Rotate role's creds
+	req = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      rotateRolePath + role,
+		Storage:   testStorage,
+	}
+
+	resp, err = testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp != nil {
+		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+	}
+
+	// Read role's creds
+	req = &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      credPrefix + role,
+		Storage:   testStorage,
+	}
+	resp, err = testBackend.HandleRequest(ctx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+
+	// Did we get the response data we expect?
+	if len(resp.Data) != 3 {
+		t.Fatalf("expected 3 items in %s but received %d", resp.Data, len(resp.Data))
+	}
+	if resp.Data["username"] != "tester" {
+		t.Fatalf("expected \"tester\" but received %q", resp.Data["username"])
+	}
+
+	respLastPassword := resp.Data["last_password"].(string)
+	if password != respLastPassword {
+		t.Fatalf("Expected returned last_password to be the first password, it was not: returned: %s, should have been %s", password, respLastPassword)
+	}
+
+	newPassword := resp.Data["current_password"].(string)
+	if password == newPassword {
+		t.Fatalf("Expected passwords to change when rotated role %s, but they did not", role)
 	}
 }
 

--- a/plugin/path_creds.go
+++ b/plugin/path_creds.go
@@ -101,7 +101,6 @@ func (b *backend) credReadOperation(ctx context.Context, req *logical.Request, f
 		resp, respErr = b.generateAndReturnCreds(ctx, engineConf, req.Storage, roleName, role, cred)
 
 	case role.PasswordLastSet.After(role.LastVaultRotation.Add(time.Second * time.Duration(engineConf.LastRotationTolerance))):
-		fmt.Println("Out of band rotate")
 		b.Logger().Warn(fmt.Sprintf(
 			"Vault rotated the password at %s, but it was rotated in AD later at %s, so rotating it again so Vault will know it",
 			role.LastVaultRotation.String(), role.PasswordLastSet.String()),

--- a/plugin/path_creds.go
+++ b/plugin/path_creds.go
@@ -101,6 +101,7 @@ func (b *backend) credReadOperation(ctx context.Context, req *logical.Request, f
 		resp, respErr = b.generateAndReturnCreds(ctx, engineConf, req.Storage, roleName, role, cred)
 
 	case role.PasswordLastSet.After(role.LastVaultRotation.Add(time.Second * time.Duration(engineConf.LastRotationTolerance))):
+		fmt.Println("Out of band rotate")
 		b.Logger().Warn(fmt.Sprintf(
 			"Vault rotated the password at %s, but it was rotated in AD later at %s, so rotating it again so Vault will know it",
 			role.LastVaultRotation.String(), role.PasswordLastSet.String()),
@@ -169,13 +170,6 @@ func (b *backend) generateAndReturnCreds(ctx context.Context, engineConf *config
 		}
 	}
 
-	// Special case where WAL would roll forward. A new role will not have a
-	// a password until creds are read, so it's possible there is no currently
-	// known password.
-	if currentPassword == "" {
-		currentPassword = newPassword
-	}
-
 	wal := rotateCredentialEntry{
 		CurrentPassword:    currentPassword,
 		LastPassword:       lastPassword,
@@ -221,7 +215,8 @@ func (b *backend) generateAndReturnCreds(ctx context.Context, engineConf *config
 	}
 
 	// Cache and save the cred.
-	entry, err := logical.StorageEntryJSON(storageKey+"/"+roleName, cred)
+	path := fmt.Sprintf("%s/%s", storageKey, roleName)
+	entry, err := logical.StorageEntryJSON(path, cred)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/path_rotate_creds.go
+++ b/plugin/path_rotate_creds.go
@@ -1,0 +1,108 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	rotateRolePath = "rotate-role/"
+)
+
+func (b *backend) pathRotateCredentials() *framework.Path {
+	return &framework.Path{
+		Pattern: rotateRolePath + framework.GenericNameRegex("name"),
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "Name of the static role",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback:                    b.pathRotateCredentialsUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback:                    b.pathRotateCredentialsUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
+			},
+		},
+
+		HelpSynopsis:    pathRotateCredentialsUpdateHelpSyn,
+		HelpDescription: pathRotateCredentialsUpdateHelpDesc,
+	}
+}
+
+func (b *backend) pathRotateCredentialsUpdate(ctx context.Context, req *logical.Request, fieldData *framework.FieldData) (*logical.Response, error) {
+	cred := make(map[string]interface{})
+
+	config, err := readConfig(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return nil, errors.New("the config is currently unset")
+	}
+
+	roleName := fieldData.Get("name").(string)
+
+	b.credLock.Lock()
+	defer b.credLock.Unlock()
+
+	role, err := b.readRole(ctx, req.Storage, roleName)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, nil
+	}
+
+	var unset time.Time
+	if role.LastVaultRotation != unset {
+		credIfc, found := b.credCache.Get(roleName)
+
+		if found {
+			b.Logger().Debug("checking cached credential")
+			cred = credIfc.(map[string]interface{})
+		} else {
+			b.Logger().Debug("checking stored credential")
+			entry, err := req.Storage.Get(ctx, storageKey+"/"+roleName)
+			if err != nil {
+				return nil, err
+			}
+			if entry == nil {
+				// If the creds aren't in storage, but roles are and we've created creds before,
+				// this is an unexpected state and something has gone wrong.
+				// Let's be explicit and error about this.
+				return nil, fmt.Errorf("should have the creds for %+v but they're not found", role)
+			}
+			if err := entry.DecodeJSON(&cred); err != nil {
+				return nil, err
+			}
+			b.credCache.SetDefault(roleName, cred)
+		}
+	}
+
+	_, err = b.generateAndReturnCreds(ctx, config, req.Storage, roleName, role, cred)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+const pathRotateCredentialsUpdateHelpSyn = `
+Request to rotate the role's credentials.
+`
+
+const pathRotateCredentialsUpdateHelpDesc = `
+This path attempts to rotate the role's credentials. 
+`

--- a/plugin/path_rotate_creds.go
+++ b/plugin/path_rotate_creds.go
@@ -66,7 +66,7 @@ func (b *backend) pathRotateCredentialsUpdate(ctx context.Context, req *logical.
 	}
 
 	var unset time.Time
-	if role.LastVaultRotation != unset {
+	if !role.LastVaultRotation.IsZero() {
 		credIfc, found := b.credCache.Get(roleName)
 
 		if found {

--- a/plugin/path_rotate_root_test.go
+++ b/plugin/path_rotate_root_test.go
@@ -1,11 +1,12 @@
 package plugin
 
 import (
+	"testing"
+	"time"
+
 	"github.com/go-errors/errors"
 	"github.com/hashicorp/vault-plugin-secrets-ad/plugin/client"
 	"github.com/hashicorp/vault/sdk/helper/ldaputil"
-	"testing"
-	"time"
 )
 
 // Tests to check root credential rotation are found in ./backend_test.go
@@ -27,7 +28,7 @@ func TestRollBackPassword(t *testing.T) {
 	}
 
 	// Test succeeds immediately with successful response.
-	if err := b.rollBackPassword(ctx, testConf, "testing"); err != nil {
+	if err := b.rollBackRootPassword(ctx, testConf, "testing"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -37,7 +38,7 @@ func TestRollBackPassword(t *testing.T) {
 	stopped := make(chan struct{})
 	go func() {
 		defer close(stopped)
-		b.rollBackPassword(ctx, testConf, "testing")
+		b.rollBackRootPassword(ctx, testConf, "testing")
 	}()
 
 	// Wait 30 seconds and then close the doneChan, which should cause rollback to stop.

--- a/plugin/rollback.go
+++ b/plugin/rollback.go
@@ -93,6 +93,9 @@ func (b *backend) handleRotateCredentialRollback(ctx context.Context, storage lo
 		return err
 	}
 
+	b.credLock.Lock()
+	defer b.credLock.Unlock()
+
 	cred := map[string]interface{}{
 		"username":         username,
 		"current_password": wal.CurrentPassword,

--- a/plugin/rollback.go
+++ b/plugin/rollback.go
@@ -41,7 +41,8 @@ func (b *backend) handleRotateCredentialRollback(ctx context.Context, storage lo
 	}
 
 	if wal.CurrentPassword == "" {
-		return fmt.Errorf("WAL does not contain a password for service account")
+		b.Logger().Warn("WAL does not contain a password for service account")
+		return nil
 	}
 
 	// Check creds for deltas. Exit if creds and WAL are the same.

--- a/plugin/rollback.go
+++ b/plugin/rollback.go
@@ -1,0 +1,75 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/mitchellh/mapstructure"
+)
+
+const (
+	rotateCredentialWAL = "rotateCredentialWAL"
+)
+
+// rotateCredentialWAL is used to store information in a WAL that can retry a
+// credential rotation in the event of partial failure.
+type rotateCredentialEntry struct {
+	LastVaultRotation  time.Time `json:"last_vault_rotation"`
+	LastPassword       string    `json:"last_password"`
+	CurrentPassword    string    `json:"current_password"`
+	RoleName           string    `json:"name"`
+	ServiceAccountName string    `json:"service_account_name"`
+	TTL                int       `json:"ttl"`
+	walID              string
+}
+
+func (b *backend) walRollback(ctx context.Context, req *logical.Request, kind string, data interface{}) error {
+	switch kind {
+	case rotateCredentialWAL:
+		return b.handleRotateCredentialRollback(ctx, req.Storage, data)
+	default:
+		return fmt.Errorf("unknown WAL entry kind %q", kind)
+	}
+}
+
+func (b *backend) handleRotateCredentialRollback(ctx context.Context, storage logical.Storage, data interface{}) error {
+	var wal rotateCredentialEntry
+	if err := mapstructure.WeakDecode(data, &wal); err != nil {
+		return err
+	}
+
+	role := &backendRole{
+		ServiceAccountName: wal.ServiceAccountName,
+		TTL:                wal.TTL,
+		LastVaultRotation:  wal.LastVaultRotation,
+	}
+
+	if err := b.writeRoleToStorage(ctx, storage, wal.RoleName, role); err != nil {
+		return err
+	}
+
+	// Although a service account name is typically my_app@example.com,
+	// the username it uses is just my_app, or everything before the @.
+	username, err := getUsername(role.ServiceAccountName)
+	if err != nil {
+		return err
+	}
+
+	cred := map[string]interface{}{
+		"username":         username,
+		"current_password": wal.CurrentPassword,
+		"last_password":    wal.LastPassword,
+	}
+
+	// Cache and save the cred.
+	entry, err := logical.StorageEntryJSON(storageKey+"/"+wal.RoleName, cred)
+	if err != nil {
+		return err
+	}
+	if err := storage.Put(ctx, entry); err != nil {
+		return err
+	}
+	return nil
+}

--- a/scripts/docker/cleanup.sh
+++ b/scripts/docker/cleanup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker rm ad --force

--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+${DIR?}/cleanup.sh
+
+set -e
+
+docker run \
+  --name=ad \
+  --hostname=ad \
+  --privileged \
+  -p 389:389 \
+  -p 636:636 \
+  -e SAMBA_DC_REALM="corp.example.net" \
+  -e SAMBA_DC_DOMAIN="EXAMPLE" \
+  -e SAMBA_DC_ADMIN_PASSWD="SuperSecretPassw0rd" \
+  -e SAMBA_DC_DNS_BACKEND="SAMBA_INTERNAL" \
+  --detach "laslabs/alpine-samba-dc" samba
+
+sleep 30
+
+LDAPTLS_REQCERT=never ldapadd -h 127.0.0.1 -Z -p 389 -w "SuperSecretPassw0rd" -D "CN=Administrator,CN=Users,DC=corp,DC=example,DC=net" -f user.ldif

--- a/scripts/docker/user.ldif
+++ b/scripts/docker/user.ldif
@@ -1,0 +1,11 @@
+dn: CN=Bob,CN=Users,DC=corp,DC=example,DC=net
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: user
+cn: Bob
+description: test account
+name: Bob
+sAMAccountName: Bob
+distinguishedName: CN=Bob,CN=Users,DC=corp,DC=example,DC=net
+userPrincipalName: Bob


### PR DESCRIPTION
This adds a new endpoint, `rotate-role`, to allow for manual rotation of a service account in AD. Currently roles are only rotated when the `creds` are read from Vault.

## Test

If you would like to test this feature, I suggest using the Samba setup script included in this PR.

First, start the AD container:

```bash
cd ./scripts/docker
./setup.sh
```

Next, assuming Vault is checked out and is your current directory, compile Vault with this PR:

```bash
go get github.com/hashicorp/vault-plugin-secrets-ad@<COMMIT HASH HERE>
make dev
```

Next, start Vault and configure it to use the secret engine:

```bash
./bin/vault server -dev -dev-root-token-id=root &
export VAULT_TOKEN=root
export VAULT_ADDR=http://127.0.0.1:8200

vault login root
vault secrets enable ad

vault write ad/config \
  binddn="CN=Administrator,CN=Users,DC=corp,DC=example,DC=net" \
  bindpass="SuperSecretPassw0rd" \
  url="ldaps://127.0.0.1" \
  insecure_tls="true" \
  userdn="CN=Users,DC=corp,DC=example,DC=net"
```

Test!
```bash
vault write ad/roles/bob service_account_name="Bob" ttl=60

vault read ad/creds/bob

vault write -f ad/rotate-role/bob

vault read ad/creds/bob
```