### PR TITLE
config: set default length only if password policy is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Unreleased
+
+### IMPROVEMENTS:
+
+* config: set default length only if password policy is missing [GH-85](https://github.com/hashicorp/vault-plugin-secrets-ad/pull/85)

--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,6 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/mitchellh/mapstructure v1.4.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/text v0.3.7
 )

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -119,7 +119,7 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 	var length int
 	if lengthRaw, ok := fieldData.GetOk("length"); ok {
 		length = lengthRaw.(int)
-	} else if !ok && passwordPolicy ==  "" {
+	} else if !ok && passwordPolicy == "" {
 		// If neither the length nor a password policy was provided, fall back
 		// to the length's field data default value.
 		length = fieldData.Get("length").(int)

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -114,9 +114,18 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 	maxTTL := fieldData.Get("max_ttl").(int)
 	lastRotationTolerance := fieldData.Get("last_rotation_tolerance").(int)
 
-	length := fieldData.Get("length").(int)
-	formatter := fieldData.Get("formatter").(string)
 	passwordPolicy := fieldData.Get("password_policy").(string)
+
+	var length int
+	if lengthRaw, ok := fieldData.GetOk("length"); ok {
+		length = lengthRaw.(int)
+	} else if !ok && passwordPolicy ==  "" {
+		// If neither the length nor a password policy was provided, fall back
+		// to the length's field data default value.
+		length = fieldData.Get("length").(int)
+	}
+
+	formatter := fieldData.Get("formatter").(string)
 
 	if pre111Val, ok := fieldData.GetOk("use_pre111_group_cn_behavior"); ok {
 		activeDirectoryConf.UsePre111GroupCNBehavior = new(bool)

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -119,7 +119,7 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 	var length int
 	if lengthRaw, ok := fieldData.GetOk("length"); ok {
 		length = lengthRaw.(int)
-	} else if !ok && passwordPolicy == "" {
+	} else if passwordPolicy == "" {
 		// If neither the length nor a password policy was provided, fall back
 		// to the length's field data default value.
 		length = fieldData.Get("length").(int)

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -144,7 +144,7 @@ func TestConfig_PasswordLength(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// submit a minimal config so we can check that we're using safe defaults
+			// Start common config fields and append what we need to test against
 			fieldData := &framework.FieldData{
 				Schema: testBackend.pathConfig().Fields,
 				Raw: map[string]interface{}{

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -109,9 +109,9 @@ func TestConfig_PasswordLength(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
+		name         string
 		rawFieldData map[string]interface{}
-		wantErr bool
+		wantErr      bool
 	}{
 		{
 			"length provided",
@@ -119,7 +119,6 @@ func TestConfig_PasswordLength(t *testing.T) {
 				"length": 32,
 			},
 			false,
-
 		},
 		{
 			"password policy provided",
@@ -137,7 +136,7 @@ func TestConfig_PasswordLength(t *testing.T) {
 			"both length and password policy provided",
 			map[string]interface{}{
 				"password_policy": "foo",
-				"length": 32,
+				"length":          32,
 			},
 			true,
 		},
@@ -173,19 +172,18 @@ func TestConfig_PasswordLength(t *testing.T) {
 			var actual map[string]interface{}
 
 			cfg := &mapstructure.DecoderConfig{
-				Result:   &actual,
-				TagName:  "json",
+				Result:  &actual,
+				TagName: "json",
 			}
 			decoder, err := mapstructure.NewDecoder(cfg)
 			assert.NoError(t, err)
 			err = decoder.Decode(config.PasswordConf)
 			assert.NoError(t, err)
 
-			for k, v := range tt.rawFieldData{
+			for k, v := range tt.rawFieldData {
 				assert.Contains(t, actual, k)
 				assert.Equal(t, actual[k], v)
 			}
 		})
 	}
 }
-


### PR DESCRIPTION
# Overview
This PR fixes an issue in the `config` endpoint where the default `length` value is always set regardless of whether `password_policy` is provided. This leads to configuration errors unless `length=0` is explicitly provided. `password_policy` and `length` [are mutually exclusive](https://www.vaultproject.io/api-docs/secret/ad#password_policy), with preferred on `password_policy`, so the engine should understand that the value is ignored and not necessary if `password_policy` is provided.

```
vault write ad/config \
    binddn=vagrant \
    bindpass=vagrant \
    url=ldaps://127.0.0.1 \
    userdn='dc=Marti,dc=com' \
    password_policy=example

Error writing data to ad/config: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/ad/config
Code: 500. Errors:

* 1 error occurred:
* cannot set password_policy and either length or formatter
```

# Design of Change
We now parse the `password_policy` first, and fallback to fetching `length`'s default value if both the length and password_policy is absent. The change should be backwards compatible.

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
_Note: Docs already describes this behavior, but the engine was not behaving as expected._
- [x] Backwards compatible
