### PR TITLE
Fix bug where updates to config would fail is password isn't provided

### DIFF
--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -34,6 +34,7 @@ func TestBackend(t *testing.T) {
 	t.Run("write config", WriteConfig)
 	t.Run("read config", ReadConfig)
 	t.Run("delete config", DeleteConfig)
+	t.Run("update config", UpdateConfig)
 
 	// Plant a config for further testing.
 	t.Run("plant config", PlantConfig)
@@ -74,6 +75,46 @@ func WriteConfig(t *testing.T) {
 		},
 	}
 	resp, err := testBackend.HandleRequest(testCtx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp != nil {
+		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+	}
+}
+
+func UpdateConfig(t *testing.T) {
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   testStorage,
+		Data: map[string]interface{}{
+			"binddn":                  "tester",
+			"password":                "pa$$w0rd",
+			"url":                     "ldap://138.91.247.105",
+			"certificate":             validCertificate,
+			"userdn":                  "dc=example,dc=com",
+			"formatter":               "mycustom{{PASSWORD}}",
+			"last_rotation_tolerance": 10,
+		},
+	}
+	resp, err := testBackend.HandleRequest(testCtx, req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatal(err)
+	}
+	if resp != nil {
+		t.Fatal("expected no response because Vault generally doesn't return it for posts")
+	}
+
+	req = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configPath,
+		Storage:   testStorage,
+		Data: map[string]interface{}{
+			"certificate": validCertificate,
+		},
+	}
+	resp, err = testBackend.HandleRequest(testCtx, req)
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatal(err)
 	}

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -92,7 +92,6 @@ func UpdateConfig(t *testing.T) {
 			"binddn":                  "tester",
 			"password":                "pa$$w0rd",
 			"url":                     "ldap://138.91.247.105",
-			"certificate":             validCertificate,
 			"userdn":                  "dc=example,dc=com",
 			"formatter":               "mycustom{{PASSWORD}}",
 			"last_rotation_tolerance": 10,

--- a/plugin/checkout_handler.go
+++ b/plugin/checkout_handler.go
@@ -127,8 +127,8 @@ func (h *checkOutHandler) CheckIn(ctx context.Context, storage logical.Storage, 
 }
 
 // LoadCheckOut returns either:
-//  - A *CheckOut and nil error if the serviceAccountName is currently managed by this engine.
-//  - A nil *Checkout and errNotFound if the serviceAccountName is not currently managed by this engine.
+//   - A *CheckOut and nil error if the serviceAccountName is currently managed by this engine.
+//   - A nil *Checkout and errNotFound if the serviceAccountName is not currently managed by this engine.
 func (h *checkOutHandler) LoadCheckOut(ctx context.Context, storage logical.Storage, serviceAccountName string) (*CheckOut, error) {
 	if ctx == nil {
 		return nil, errors.New("ctx must be provided")
@@ -174,9 +174,9 @@ func (h *checkOutHandler) Delete(ctx context.Context, storage logical.Storage, s
 
 // retrievePassword is a utility function for grabbing a service account's password from storage.
 // retrievePassword will return:
-//  - "password", nil if it was successfully able to retrieve the password.
-//  - errNotFound if there's no password presently.
-//  - Some other err if it was unable to complete successfully.
+//   - "password", nil if it was successfully able to retrieve the password.
+//   - errNotFound if there's no password presently.
+//   - Some other err if it was unable to complete successfully.
 func retrievePassword(ctx context.Context, storage logical.Storage, serviceAccountName string) (string, error) {
 	entry, err := storage.Get(ctx, passwordStoragePrefix+serviceAccountName)
 	if err != nil {

--- a/plugin/client/fieldregistry.go
+++ b/plugin/client/fieldregistry.go
@@ -9,14 +9,13 @@ import (
 //
 // Example: Accessing constants
 //
-//   FieldRegistry.AccountExpires
-//   FieldRegistry.BadPasswordCount
+//	FieldRegistry.AccountExpires
+//	FieldRegistry.BadPasswordCount
 //
 // Example: Utility methods
 //
-//   FieldRegistry.List()
-//   FieldRegistry.Parse("givenName")
-//
+//	FieldRegistry.List()
+//	FieldRegistry.Parse("givenName")
 var FieldRegistry = newFieldRegistry()
 
 // newFieldRegistry iterates through all the fields in the registry,

--- a/plugin/client/time.go
+++ b/plugin/client/time.go
@@ -27,11 +27,11 @@ func ParseTicks(ticks string) (time.Time, error) {
 // TicksToTime converts an ActiveDirectory time in ticks to a time.
 // This algorithm is summarized as:
 //
-// 		Many dates are saved in Active Directory as Large Integer values.
-// 		These attributes represent dates as the number of 100-nanosecond intervals since 12:00 AM January 1, 1601.
-//		100-nanosecond intervals, equal to 0.0000001 seconds, are also called ticks.
-//		Dates in Active Directory are always saved in Coordinated Universal Time, or UTC.
-//		More: https://social.technet.microsoft.com/wiki/contents/articles/31135.active-directory-large-integer-attributes.aspx
+//	Many dates are saved in Active Directory as Large Integer values.
+//	These attributes represent dates as the number of 100-nanosecond intervals since 12:00 AM January 1, 1601.
+//	100-nanosecond intervals, equal to 0.0000001 seconds, are also called ticks.
+//	Dates in Active Directory are always saved in Coordinated Universal Time, or UTC.
+//	More: https://social.technet.microsoft.com/wiki/contents/articles/31135.active-directory-large-integer-attributes.aspx
 //
 // If we directly follow the above algorithm we encounter time.Duration limits of 290 years and int overflow issues.
 // Thus below, we carefully sidestep those.

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -2,9 +2,10 @@ package plugin
 
 import (
 	"context"
+	"testing"
+
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"


### PR DESCRIPTION
If a user tries to update the config and doesn't provide the binddn or bindpass, it will fail with an error: `cannot derive UserBindDN`. This PR adds a read operation to update to first check storage for a config and pass it into the config builder. I've added a test to cover this, which fails without the patch:

```bash
$ go test -v -run TestBackend
=== RUN   TestBackend
=== RUN   TestBackend/write_config
=== RUN   TestBackend/read_config
=== RUN   TestBackend/delete_config
=== RUN   TestBackend/update_config
    backend_test.go:119: cannot derive UserBindDN
=== RUN   TestBackend/plant_config
=== RUN   TestBackend/write_role
=== RUN   TestBackend/read_role
=== RUN   TestBackend/list_roles
=== RUN   TestBackend/delete_role
=== RUN   TestBackend/plant_role
=== RUN   TestBackend/read_cred
=== RUN   TestBackend/rotate_role_creds
=== RUN   TestBackend/rollback_role_creds
=== RUN   TestBackend/discard_WAL
=== RUN   TestBackend/rotate_root_creds
=== RUN   TestBackend/rotate_root_creds_with_write
--- FAIL: TestBackend (0.01s)
    --- PASS: TestBackend/write_config (0.00s)
    --- PASS: TestBackend/read_config (0.00s)
    --- PASS: TestBackend/delete_config (0.00s)
    --- FAIL: TestBackend/update_config (0.00s)
    --- PASS: TestBackend/plant_config (0.00s)
    --- PASS: TestBackend/write_role (0.00s)
    --- PASS: TestBackend/read_role (0.00s)
    --- PASS: TestBackend/list_roles (0.00s)
    --- PASS: TestBackend/delete_role (0.00s)
    --- PASS: TestBackend/plant_role (0.00s)
    --- PASS: TestBackend/read_cred (0.00s)
    --- PASS: TestBackend/rotate_role_creds (0.00s)
    --- PASS: TestBackend/rollback_role_creds (0.00s)
    --- PASS: TestBackend/discard_WAL (0.00s)
    --- PASS: TestBackend/rotate_root_creds (0.00s)
    --- PASS: TestBackend/rotate_root_creds_with_write (0.00s)
FAIL
exit status 1
FAIL	github.com/hashicorp/vault-plugin-secrets-ad/plugin	1.123s
```