### PR TITLE
Remove gox in favor of go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 TOOL?=vault-plugin-secrets-active-directory
 TEST?=$$(go list ./... | grep -v /vendor/ | grep -v teamcity)
 VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
-EXTERNAL_TOOLS=\
-	github.com/mitchellh/gox \
-	github.com/golang/dep/cmd/dep
+EXTERNAL_TOOLS=
 BUILD_TAGS?=${TOOL}
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 

--- a/README.md
+++ b/README.md
@@ -7,22 +7,22 @@ This plugin provides Active Directory functionality to Vault.
 
 ## Quick Links
 - Vault Website: https://www.vaultproject.io
-- Active Directory Docs: https://www.vaultproject.io/docs/secrets/ad/index.html
+- Active Directory Docs: https://developer.hashicorp.com/vault/docs/secrets/ad
 - Main Project Github: https://www.github.com/hashicorp/vault
 
 ## Getting Started
 
-This is a [Vault plugin](https://www.vaultproject.io/docs/internals/plugins.html)
+This is a [Vault plugin](https://developer.hashicorp.com/vault/docs/plugins)
 and is meant to work with Vault. This guide assumes you have already installed Vault
 and have a basic understanding of how Vault works.
 
-Otherwise, first read this guide on how to [get started with Vault](https://www.vaultproject.io/intro/getting-started/install.html).
+Otherwise, first read this guide on how to [get started with Vault](https://developer.hashicorp.com/vault/tutorials/getting-started/getting-started-install).
 
-To learn specifically about how plugins work, see documentation on [Vault plugins](https://www.vaultproject.io/docs/internals/plugins.html).
+To learn specifically about how plugins work, see documentation on [Vault plugins](https://developer.hashicorp.com/vault/docs/plugins).
 
 ## Usage
 
-Please see [documentation for the plugin](https://www.vaultproject.io/docs/secrets/ad/index.html)
+Please see [documentation for the plugin](https://developer.hashicorp.com/vault/docs/secrets/ad)
 on the Vault website.
 
 This plugin is currently built into Vault and by default is accessed
@@ -44,14 +44,6 @@ If you wish to work on this plugin, you'll first need
 
 For local dev first make sure Go is properly installed, including
 setting up a [GOPATH](https://golang.org/doc/code.html#GOPATH).
-Next, clone this repository into
-`$GOPATH/src/github.com/hashicorp/vault-plugin-secrets-ad`.
-You can then download any required build tools by bootstrapping your
-environment:
-
-```sh
-$ make bootstrap
-```
 
 To compile a development version of this plugin, run `make` or `make dev`.
 This will put the plugin binary in the `bin` and `$GOPATH/bin` folders. `dev`
@@ -63,10 +55,10 @@ $ make dev
 ```
 
 Put the plugin binary into a location of your choice. This directory
-will be specified as the [`plugin_directory`](https://www.vaultproject.io/docs/configuration/index.html#plugin_directory)
+will be specified as the [`plugin_directory`](https://developer.hashicorp.com/vault/docs/configuration#plugin_directory)
 in the Vault config used to start the server.
 
-```json
+```hcl
 plugin_directory = "path/to/plugin/directory"
 ```
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,9 +4,11 @@
 
 
 TOOL=vault-plugin-secrets-active-directory
-#
+
 # This script builds the application from source for multiple platforms.
 set -e
+
+GO_CMD=${GO_CMD:-go}
 
 # Get the parent directory of where this script is.
 SOURCE="${BASH_SOURCE[0]}"
@@ -23,11 +25,6 @@ BUILD_TAGS="${BUILD_TAGS}:-${TOOL}"
 GIT_COMMIT="$(git rev-parse HEAD)"
 GIT_DIRTY="$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)"
 
-# Determine the arch/os combos we're building for
-XC_ARCH=${XC_ARCH:-"386 amd64"}
-XC_OS=${XC_OS:-linux darwin windows freebsd openbsd netbsd solaris}
-XC_OSARCH=${XC_OSARCH:-"linux/386 linux/amd64 linux/arm linux/arm64 darwin/386 darwin/amd64 windows/386 windows/amd64 freebsd/386 freebsd/amd64 freebsd/arm openbsd/386 openbsd/amd64 openbsd/arm netbsd/386 netbsd/amd64 netbsd/arm solaris/amd64"}
-
 GOPATH=${GOPATH:-$(go env GOPATH)}
 case $(uname) in
     CYGWIN*)
@@ -41,20 +38,13 @@ rm -f bin/*
 rm -rf pkg/*
 mkdir -p bin/
 
-# If its dev mode, only build for our self
-if [ "${VAULT_DEV_BUILD}x" != "x" ]; then
-    XC_OS=$(go env GOOS)
-    XC_ARCH=$(go env GOARCH)
-    XC_OSARCH=$(go env GOOS)/$(go env GOARCH)
-fi
-
 # Build!
 echo "==> Building..."
-gox \
-    -osarch="${XC_OSARCH}" \
+${GO_CMD} build \
+    -gcflags "${GCFLAGS}" \
     -ldflags "-X github.com/hashicorp/${TOOL}/version.GitCommit='${GIT_COMMIT}${GIT_DIRTY}'" \
-    -output "pkg/{{.OS}}_{{.Arch}}/${TOOL}" \
-    -tags="${BUILD_TAGS}" \
+    -o "bin/${TOOL}" \
+    -tags "${BUILD_TAGS}" \
     .
 
 # Move all the compiled things to the $GOPATH/bin
@@ -62,25 +52,8 @@ OLDIFS=$IFS
 IFS=: MAIN_GOPATH=($GOPATH)
 IFS=$OLDIFS
 
-# Copy our OS/Arch to the bin/ directory
-DEV_PLATFORM="./pkg/$(go env GOOS)_$(go env GOARCH)"
-for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
-    cp ${F} bin/
-    cp ${F} ${MAIN_GOPATH}/bin/
-done
-
-if [ "${VAULT_DEV_BUILD}x" = "x" ]; then
-    # Zip and copy to the dist dir
-    echo "==> Packaging..."
-    for PLATFORM in $(find ./pkg -mindepth 1 -maxdepth 1 -type d); do
-        OSARCH=$(basename ${PLATFORM})
-        echo "--> ${OSARCH}"
-
-        pushd $PLATFORM >/dev/null 2>&1
-        zip ../${OSARCH}.zip ./*
-        popd >/dev/null 2>&1
-    done
-fi
+rm -f ${MAIN_GOPATH}/bin/${TOOL}
+cp bin/${TOOL} ${MAIN_GOPATH}/bin/
 
 # Done!
 echo


### PR DESCRIPTION
gox is no longer maintained and releases are done with `go build` now. See https://github.com/hashicorp/vault/pull/16353 where we removed gox in Vault.

