### PR TITLE
Update changelog in preparation for `v0.16.0` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 ## Unreleased
 
+## v0.16.0
+
 ### IMPROVEMENTS:
 
 * enable plugin multiplexing [GH-99](https://github.com/hashicorp/vault-plugin-secrets-ad/pull/99)
 * update dependencies
-  * `github.com/hashicorp/vault/api` v1.9.0
-  * `github.com/hashicorp/vault/sdk` v0.8.1
+  * `github.com/hashicorp/vault/api` v1.9.1
+  * `github.com/hashicorp/vault/sdk` v0.9.0
+  * `golang.org/x/text` v0.9.0
+  * `golang.org/x/net` v0.7.0
 
 ## v0.15.0
 


### PR DESCRIPTION
Updates the changelog for the upcoming plugin release